### PR TITLE
[DESIGN]: Button 컴포넌트가 버튼 태그의 기본 속성을 이용할 수 있도록 props 수정

### DIFF
--- a/src/components/common/button/CtaButton.tsx
+++ b/src/components/common/button/CtaButton.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import * as S from './CtaButton.style.ts';
 
-interface CtaButtonProps {
-  children: React.ReactNode; // 버튼 내부 텍스트 or 요소
-  onClick?: () => void; // 클릭 이벤트 핸들러
-  disabled?: boolean; // 버튼 비활성화 여부
+type CtaButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: 'primary' | 'secondary';
-  // 추후 button ratio에 관한 props도 추가해야함
-}
+};
 
-const CtaButton: React.FC<CtaButtonProps> = ({ children, onClick, disabled = false, variant }) => {
+const CtaButton: React.FC<CtaButtonProps> = ({
+  children,
+  onClick,
+  disabled = false,
+  variant,
+}) => {
   return (
-    <S.CtaButtonWrapper onClick={onClick} disabled={disabled} $variant={variant}>
+    <S.CtaButtonWrapper
+      onClick={onClick}
+      disabled={disabled}
+      $variant={variant}
+    >
       {children}
     </S.CtaButtonWrapper>
   );

--- a/src/components/common/button/IconButton.tsx
+++ b/src/components/common/button/IconButton.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import * as S from './IconButton.style.ts';
 
-interface IconButtonProps {
+type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   children: React.ReactNode;
   onClick?: () => void; // 클릭 이벤트 핸들러
-}
+};
 
 const IconButton: React.FC<IconButtonProps> = ({ children, onClick }) => {
-  return <S.IconButtonWrapper onClick={onClick}>{children}</S.IconButtonWrapper>;
+  return (
+    <S.IconButtonWrapper onClick={onClick}>{children}</S.IconButtonWrapper>
+  );
 };
 
 export default IconButton;

--- a/src/components/common/button/IconButton.tsx
+++ b/src/components/common/button/IconButton.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import * as S from './IconButton.style.ts';
 
-type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  children: React.ReactNode;
-  onClick?: () => void; // 클릭 이벤트 핸들러
-};
+type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 const IconButton: React.FC<IconButtonProps> = ({ children, onClick }) => {
   return (

--- a/src/components/common/button/TextButton.tsx
+++ b/src/components/common/button/TextButton.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import * as S from './TextButton.style.ts';
 
-interface TextButtonProps {
+type TextButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   children: React.ReactNode;
   onClick?: () => void; // 클릭 이벤트 핸들러
-}
+};
 
 const TextButton: React.FC<TextButtonProps> = ({ children, onClick }) => {
-  return <S.TextButtonWrapper onClick={onClick}>{children}</S.TextButtonWrapper>;
+  return (
+    <S.TextButtonWrapper onClick={onClick}>{children}</S.TextButtonWrapper>
+  );
 };
 
 export default TextButton;

--- a/src/components/common/button/TextButton.tsx
+++ b/src/components/common/button/TextButton.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import * as S from './TextButton.style.ts';
 
-type TextButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  children: React.ReactNode;
-  onClick?: () => void; // 클릭 이벤트 핸들러
-};
+type TextButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 const TextButton: React.FC<TextButtonProps> = ({ children, onClick }) => {
   return (


### PR DESCRIPTION
## 🚀 반영 브랜치
`design/10-common-component-button-edit` → `dev`

## 📝 작업 내용

Button 컴포넌트가 버튼 태그의 기본 속성을 이용할 수 있도록 props 수정하였습니다.

## 🌠 스크린샷
⬇️ 이렇게 코드를 수정하여서
![스크린샷 2025-03-07 오후 4 33 16](https://github.com/user-attachments/assets/c697de96-9670-4d2b-9b2c-5af3f043007e)

⬇️ 이제 아래의 그림
![스크린샷 2025-03-07 오후 4 35 07](https://github.com/user-attachments/assets/8d6c249e-91d4-41c6-abb6-78ab91469a72)
처럼 기본 버튼 태그의 props를 버튼 컴포넌트 (Icon, Cta, Text)에서 이용하실 수 있습니다!

## ✏️ 후속 작업
- UI 완성을 마저 하겠습니다!

## 📌 이슈 번호

- #10 
