### PR TITLE
[FIX]: 유저 데이터 비동기 처리 개선 및 redirection 수정

### DIFF
--- a/src/hooks/useUserData.tsx
+++ b/src/hooks/useUserData.tsx
@@ -1,10 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 import { getUserData } from '../api/login/login';
+import { useAuthStore } from '../store/useAuthStore';
 
 export default function useUserData() {
+  const { userInfo, setUserInfo } = useAuthStore();
+
   const userDataQuery = useQuery({
     queryKey: ['userData'],
-    queryFn: getUserData,
+    queryFn: async () => {
+      const data = await getUserData();
+      if (data) {
+        setUserInfo(data);
+      } else {
+        setUserInfo(null);
+      }
+      return data;
+    },
+    enabled: !!userInfo?.role,
   });
 
   return {

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -3,7 +3,7 @@ import TextButton from '../../components/common/button/TextButton.tsx';
 import { Input } from '../../components/common/input/Input.tsx';
 import Layout from '../../components/common/layout/Layout.tsx';
 import * as S from './Login.style.ts';
-import { loginUser } from '../../api/login/login.ts';
+import { getUserData, loginUser } from '../../api/login/login.ts';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../store/useAuthStore.ts';
 
@@ -11,7 +11,7 @@ export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
-  const { userInfo } = useAuthStore();
+  const { userInfo, setUserInfo } = useAuthStore();
 
   useEffect(() => {
     if (userInfo) {
@@ -23,6 +23,8 @@ export default function Login() {
     e.preventDefault();
     const response = await loginUser({ email, password });
     if (response) {
+      const userData = await getUserData();
+      setUserInfo(userData);
       console.log('로그인 성공');
       navigate(response.role === 'USER' ? '/dashboard' : '/admin/dashboard');
     }

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -10,10 +10,10 @@ interface User {
 
 interface AuthStore {
   userInfo: User | null;
-  setUserInfo: (user: User) => void;
+  setUserInfo: (user: User | null) => void;
 }
 
 export const useAuthStore = create<AuthStore>((set) => ({
   userInfo: null,
-  setUserInfo: (user) => set({ userInfo: user }),
+  setUserInfo: (user: User | null) => set({ userInfo: user }),
 }));


### PR DESCRIPTION
## 🚀 반영 브랜치
`fix/39-user-data-redirection` → `dev`

## 📝 작업 내용

로그인 시 유저 정보가 비동기적으로 처리되면서 생긴 오류를 수정하였습니다.
### 문제
- 로그인 후, 유저 정보가 비동기적으로 처리되어 대시보드로 바로 이동되지 않음
- 캐시가 삭제되면 로그인 페이지로 이동시켜야 하는데 새로고침하지 않으면 이동하지 않음

### 해결
- 로그인 성공하면 `setUserInfo`에 `getUserData`의 정보를 넣어 업데이트 하여 유저 정보가 준비된 후 대시보드로 이동하도록 수정
- 캐시 삭제 시 `tanstack query`에서 유저 데이터 없을 경우 `setUserInfo(null)`로 처리 하여 로그인 페이지로 리디렉션되도록 처리
----- 
- 현재 API가 두 개로 나뉘어 있기 때문에, 로그인 시 유저 데이터를 두 번 호출할 수 밖에 없음
- 로그인 성공 시 유저 데이터를 한 번에 받아와야 할지 고민 중.. 
  (그런데 이렇게 되면 보안에 문제가 있을 수 있지 않나?😭)

## 🌠 스크린샷

## ✏️ 후속 작업

## 📌 이슈 번호

- #39 
