### PR TITLE
[FIX]: 로그인 후 관리자/유저 메인 페이지 외 다른 페이지 접근 불가 문제 해결

### DIFF
--- a/src/hooks/useUserData.tsx
+++ b/src/hooks/useUserData.tsx
@@ -3,7 +3,7 @@ import { getUserData } from '../api/login/login';
 import { useAuthStore } from '../store/useAuthStore';
 
 export default function useUserData() {
-  const { userInfo, setUserInfo } = useAuthStore();
+  const { setUserInfo } = useAuthStore();
 
   const userDataQuery = useQuery({
     queryKey: ['userData'],
@@ -16,7 +16,6 @@ export default function useUserData() {
       }
       return data;
     },
-    enabled: !!userInfo?.role,
   });
 
   return {

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import TextButton from '../../components/common/button/TextButton.tsx';
 import { Input } from '../../components/common/input/Input.tsx';
 import Layout from '../../components/common/layout/Layout.tsx';
@@ -11,13 +11,7 @@ export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
-  const { userInfo, setUserInfo } = useAuthStore();
-
-  useEffect(() => {
-    if (userInfo) {
-      navigate(userInfo.role === 'ADMIN' ? '/admin/dashboard' : '/dashboard');
-    }
-  }, [userInfo, navigate]);
+  const { setUserInfo } = useAuthStore();
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## 🚀 반영 브랜치
`fix/47-user-access-issue` → `dev`

## 📝 작업 내용

- 로그인 후 관리자와 유저는 각자의 대시보드로 이동할 수 있으나, 다른 페이지로의 접근이 차단되어 로그인 페이지로 리디렉션되는 문제가 발생
- `useQuery`에서 `enabled` 옵션이 조건부로 설정되어 있어서 `userInfo` 상태가 `null`일 때 쿼리가 실행x → 다른 페이지 접근 불가
- `enabled` 옵션 제거하여 해결 (`enabled: true`와 같음)

## 🌠 스크린샷

## ✏️ 후속 작업

## 📌 이슈 번호

- #47 
