### PR TITLE
✨ feat: 관리자 dashboard 컨퍼런스 리스트 API 통신

### DIFF
--- a/src/api/admin/conference/getConferences.ts
+++ b/src/api/admin/conference/getConferences.ts
@@ -1,0 +1,10 @@
+import API from '../../axiosIntance';
+
+export const getConferences = async () => {
+  try {
+    const response = await API.get('/admin/conference');
+    return response.data;
+  } catch (error) {
+    console.log('컨퍼런스 조회 실패', error);
+  }
+};

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -1,5 +1,0 @@
-const AdminDashboard = () => {
-  return <div>AdminDashboard</div>;
-};
-
-export default AdminDashboard;

--- a/src/pages/admin/adminDashboard/AdminDashboard.style.ts
+++ b/src/pages/admin/adminDashboard/AdminDashboard.style.ts
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+export const Container = styled.div`
+  padding: 20px;
+  max-width: 1200px;
+  margin: auto;
+`;
+
+export const Title = styled.h1`
+  text-align: center;
+  margin-bottom: 20px;
+`;
+
+export const CardGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+`;
+
+export const ConferenceCard = styled.div`
+  background: #fff;
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease-in-out;
+
+  &:hover {
+    transform: translateY(-5px);
+  }
+`;
+
+export const CardTitle = styled.h2`
+  font-size: 20px;
+  margin-bottom: 10px;
+`;
+
+export const CardInfo = styled.p`
+  font-size: 16px;
+  margin: 5px 0;
+`;
+
+export const CardDescription = styled.p`
+  font-size: 14px;
+  color: #666;
+  margin-top: 10px;
+`;

--- a/src/pages/admin/adminDashboard/AdminDashboard.tsx
+++ b/src/pages/admin/adminDashboard/AdminDashboard.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { getConferences } from '../../../api/admin/conference/getConferences';
+import * as S from './AdminDashboard.style';
+
+type confType = {
+  id: number;
+  name: string;
+  description: string;
+  location: string;
+  conferenceAt: string;
+  capacity: string;
+  hasSessions: boolean;
+};
+const AdminDashboard = () => {
+  const [confDatas, setConfDatas] = useState<confType[]>([]);
+
+  useEffect(() => {
+    const fetchConferences = async () => {
+      try {
+        const res = await getConferences();
+        console.log('컨퍼런스 데이터:', res);
+        setConfDatas(res);
+      } catch (error) {
+        console.error('컨퍼런스 데이터 조회 실패', error);
+      }
+    };
+
+    fetchConferences();
+  }, []);
+
+  //임시 디자인
+  return (
+    <S.Container>
+      <S.Title>관리자 대시보드</S.Title>
+      <S.CardGrid>
+        {confDatas.map((conf) => (
+          <S.ConferenceCard key={conf.id}>
+            <S.CardTitle>{conf.name}</S.CardTitle>
+            <S.CardInfo>📍 장소: {conf.location}</S.CardInfo>
+            <S.CardInfo>
+              📅 일정: {new Date(conf.conferenceAt).toLocaleDateString()}
+            </S.CardInfo>
+            <S.CardInfo>👥 최대 참석: {conf.capacity}명</S.CardInfo>
+            <S.CardInfo>
+              {conf.hasSessions ? '✅ 세션 포함' : '❌ 세션 없음'}
+            </S.CardInfo>
+            <S.CardDescription>{conf.description}</S.CardDescription>
+          </S.ConferenceCard>
+        ))}
+      </S.CardGrid>
+    </S.Container>
+  );
+};
+
+export default AdminDashboard;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -5,7 +5,7 @@ import Reservation from './pages/reserve/Reservation';
 import ReservationComplete from './pages/reserve/ReservationComplete';
 import SignUp from './pages/login/Signup';
 import UserDashboard from './pages/user/UserDashboard';
-import AdminDashboard from './pages/admin/AdminDashboard';
+import AdminDashboard from './pages/admin/adminDashboard/AdminDashboard';
 import ConferenceEdit from './pages/admin/ConferenceEdit';
 import DeviceConnect from './pages/admin/DeviceConnect';
 import Visitors from './pages/admin/Visitors';


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/58-adminDashboard → `dev`

## 📝 작업 내용

관리자 dashboard 컨퍼런스 리스트 API 통신

-임의로 디자인 해놨습니당

## 🌠 스크린샷
<img width="862" alt="image" src="https://github.com/user-attachments/assets/35ceb87d-d7c6-48ed-86da-852389fd0074" />

## ✏️ 후속 작업

## 📌 이슈 번호

- #58 
