### PR TITLE
[STYLE]: 미디어 쿼리 오류 수정

### DIFF
--- a/src/styles/breakpoints.ts
+++ b/src/styles/breakpoints.ts
@@ -11,8 +11,9 @@ const media = {
   expandedLayout: `@media (min-width: ${breakpoints.expandedMin})`,
 
   // 컴포넌트에 적용할 쿼리 헬퍼 함수
-  mobile: `@media (max-width: ${breakpoints.desktopMin})`,
+  mobile: `@media (min-width: ${breakpoints.mobileMin})`,
   desktop: `@media (min-width: ${breakpoints.desktopMin})`,
+  expanded: `@media (min-width: ${breakpoints.expandedMin})`,
 };
 
 export { breakpoints, media };


### PR DESCRIPTION
## 🚀 반영 브랜치
`style/87-breakpoints-update` → `dev`

## 📝 작업 내용

- `mobile` 미디어 쿼리가 `max-width`로 되어 있던 오류를 수정하여 `min-width`로 변경
- `breakpoints.desktopMin`을 기준으로 설정되어 있던 부분을 올바르게 수정


## 🌠 스크린샷

## ✏️ 후속 작업

## 📌 이슈 번호

- #87 
