### PR TITLE
[FEAT]: 컨퍼런스 카드 컴포넌트 구현 및 입장 현황 페이지 적용

### DIFF
--- a/src/components/common/card/admin/adminEntryCard/AdminEntryCard.style.ts
+++ b/src/components/common/card/admin/adminEntryCard/AdminEntryCard.style.ts
@@ -1,0 +1,91 @@
+import styled from 'styled-components';
+import { media } from '../../../../../styles/breakpoints';
+
+export const CardContainer = styled.div`
+  display: grid;
+  gap: var(--spacing-4);
+
+  ${media.mobileLayout} {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-12);
+  }
+
+  ${media.desktopLayout} {
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--spacing-28);
+  }
+
+  ${media.expandedLayout} {
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  }
+`;
+
+export const Card = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  background-color: ${({ theme }) => theme.colors.background.white};
+  border: 1px solid ${({ theme }) => theme.colors.border.primary};
+  border-radius: var(--spacing-12);
+  padding: var(--spacing-12) var(--spacing-16);
+  gap: var(--spacing-4);
+
+  ${({ theme }) => theme.media.mobile} {
+    height: 122px;
+  }
+
+  ${({ theme }) => theme.media.desktop} {
+    height: 132px;
+  }
+
+  ${({ theme }) => theme.media.expanded} {
+    height: 132px;
+  }
+`;
+
+export const CardHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const TotalCount = styled.div`
+  ${({ theme }) => theme.media.mobile} {
+    font: var(--font-title-xs);
+  }
+
+  ${({ theme }) => theme.media.desktop} {
+    font: var(--font-body-l);
+  }
+
+  ${({ theme }) => theme.media.expanded} {
+    font: var(--font-body-l);
+  }
+`;
+
+export const EntryCount = styled.div`
+  flex-grow: 1;
+  font-weight: bold;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  ${({ theme }) => theme.media.mobile} {
+    font: var(--font-title-l);
+  }
+
+  ${({ theme }) => theme.media.desktop} {
+    font: var(--font-title-xl-2);
+  }
+
+  ${({ theme }) => theme.media.expanded} {
+    font: var(--font-title-xl-2);
+  }
+`;
+
+export const CornerBox = styled.button`
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+`;

--- a/src/components/common/card/admin/adminEntryCard/AdminEntryCard.tsx
+++ b/src/components/common/card/admin/adminEntryCard/AdminEntryCard.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { getConferenceInfo } from '../../../../../api/reserve/getConferenceInfo';
+import * as S from './AdminEntryCard.style.ts';
+import { Tag } from '../../../tag/Tag.tsx';
+import Icon from '../../../icon/Icon.tsx';
+
+interface ConferenceInfo {
+  id: number;
+  name: string;
+  startTime: string;
+  attend: number;
+  sessions: {
+    id: number;
+    name: string;
+    startTime: string;
+  }[];
+}
+
+export default function AdminEntryCard() {
+  const [conferInfo, setConferInfo] = useState<ConferenceInfo | null>(null);
+  const [isMobile, setIsMobile] = useState<boolean>(false);
+
+  useEffect(() => {
+    const fetchConference = async () => {
+      const response = await getConferenceInfo(1);
+      if (response) {
+        setConferInfo(response);
+      }
+    };
+    fetchConference();
+
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+
+    return () => {
+      window.removeEventListener('resize', checkMobile);
+    };
+  }, []);
+
+  const sortedSessions = conferInfo?.sessions.sort((a, b) => a.id - b.id);
+
+  return (
+    <>
+      {conferInfo ? (
+        <S.CardContainer>
+          <S.Card>
+            <S.CardHeader>
+              <S.TotalCount>총 500명</S.TotalCount>
+              <S.CornerBox>
+                <Icon
+                  name="rightArrow"
+                  color="#909298"
+                  size={isMobile ? 20 : 24}
+                />
+              </S.CornerBox>
+            </S.CardHeader>
+            <S.EntryCount>
+              {conferInfo.attend ? conferInfo.attend : 0}명 입장
+            </S.EntryCount>
+            <Tag isEntryStatus={true}>{conferInfo.name}</Tag>
+          </S.Card>
+
+          {sortedSessions?.map((session) => (
+            <S.Card key={session.id}>
+              <S.CardHeader>
+                <S.TotalCount>총 0명</S.TotalCount>
+                <S.CornerBox>
+                  <Icon
+                    name="rightArrow"
+                    color="#909298"
+                    size={isMobile ? 20 : 24}
+                  />
+                </S.CornerBox>
+              </S.CardHeader>
+              <S.EntryCount>0명 입장</S.EntryCount>
+              <Tag isEntryStatus={true}>{session.name}</Tag>
+            </S.Card>
+          ))}
+        </S.CardContainer>
+      ) : (
+        <div>없음</div>
+      )}
+    </>
+  );
+}

--- a/src/components/common/icon/Icon.tsx
+++ b/src/components/common/icon/Icon.tsx
@@ -7,6 +7,7 @@ import ErrorIcon from './ErrorIcon';
 import SuccessIcon from './SuccessIcon';
 import CloseIcon from './CloseIcon';
 import LogoIcon from './LogoIcon';
+import RightArrow from './RightArrow';
 
 const Icon: React.FC<IconProps> = ({ name, size = 24, color = '#000' }) => {
   switch (name) {
@@ -24,6 +25,8 @@ const Icon: React.FC<IconProps> = ({ name, size = 24, color = '#000' }) => {
       return <SuccessIcon size={size} color={color} />;
     case 'close':
       return <CloseIcon size={size} color={color} />;
+    case 'rightArrow':
+      return <RightArrow size={size} color={color} />;
     default:
       return null;
   }

--- a/src/components/common/icon/RightArrow.tsx
+++ b/src/components/common/icon/RightArrow.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { BaseIconProps } from './types';
+
+const CloseIcon: React.FC<BaseIconProps> = ({ size = 24, color = '#000' }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      color={color}
+    >
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M8.07841 2.71042L17.1552 11.2968C17.2334 11.3716 17.2955 11.4616 17.3376 11.5612C17.3797 11.6609 17.401 11.7682 17.4 11.8764C17.4005 11.987 17.3791 12.0967 17.3371 12.199C17.2951 12.3014 17.2333 12.3944 17.1552 12.4728C14.0112 15.54 10.9812 18.5004 8.06521 21.354C7.91521 21.4944 7.31521 21.8436 6.85201 21.3252C6.38881 20.8056 6.66961 20.3532 6.85201 20.166L15.3336 11.8764L6.85201 3.88642C6.55681 3.47922 6.58081 3.10362 6.92401 2.75962C7.26801 2.41562 7.65281 2.39842 8.07841 2.71042Z"
+        fill={color}
+      />
+    </svg>
+  );
+};
+
+export default CloseIcon;

--- a/src/components/common/icon/types.ts
+++ b/src/components/common/icon/types.ts
@@ -5,7 +5,8 @@ export type IconName =
   | 'send'
   | 'error'
   | 'success'
-  | 'close';
+  | 'close'
+  | 'rightArrow';
 
 export interface BaseIconProps {
   size?: number;

--- a/src/components/common/tag/Tag.style.ts
+++ b/src/components/common/tag/Tag.style.ts
@@ -2,10 +2,15 @@ import styled from 'styled-components';
 import { TagProps } from './Tag';
 
 export const Tag = styled.span<TagProps>`
-  display: inline-flex;
+  display: block;
   font: var(--font-caption-s);
   padding: var(--spacing-4) var(--spacing-12);
   border-radius: var(--radius-9999);
+  text-align: center;
+  width: ${({ isEntryStatus }) => (isEntryStatus ? '100%' : 'auto')};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   ${({ variant, theme }) => {
     switch (variant) {

--- a/src/components/common/tag/Tag.tsx
+++ b/src/components/common/tag/Tag.tsx
@@ -4,8 +4,17 @@ import * as S from './Tag.style';
 export interface TagProps {
   variant?: 'primary' | 'secondary' | 'tertiary';
   children: React.ReactNode;
+  isEntryStatus?: boolean;
 }
 
-export const Tag = ({ variant = 'primary', children }: TagProps) => {
-  return <S.Tag variant={variant}>{children}</S.Tag>;
+export const Tag = ({
+  variant = 'primary',
+  children,
+  isEntryStatus,
+}: TagProps) => {
+  return (
+    <S.Tag variant={variant} isEntryStatus={isEntryStatus}>
+      {children}
+    </S.Tag>
+  );
 };

--- a/src/pages/admin/Visitors.style.ts
+++ b/src/pages/admin/Visitors.style.ts
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+
+export const TitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+  padding: var(--spacing-24) var(--spacing-20);
+  margin-bottom: var(--spacing-36);
+`;
+
+export const Title = styled.h1`
+  ${({ theme }) => theme.media.mobile} {
+    font: var(--font-title-xl-2);
+  }
+
+  ${({ theme }) => theme.media.desktop} {
+    font: var(--font-title-xxl-2);
+  }
+
+  ${({ theme }) => theme.media.expanded} {
+    font: var(--font-title-xxl-2);
+  }
+`;
+
+export const Description = styled.h2`
+  ${({ theme }) => theme.media.mobile} {
+    font: var(--font-body-m);
+    color: ${({ theme }) => theme.colors.typo.tertiary};
+  }
+
+  ${({ theme }) => theme.media.desktop} {
+    font: var(--font-body-xl);
+    color: ${({ theme }) => theme.colors.typo.tertiary};
+  }
+
+  ${({ theme }) => theme.media.expanded} {
+    font: var(--font-body-xl);
+    color: ${({ theme }) => theme.colors.typo.tertiary};
+  }
+`;

--- a/src/pages/admin/Visitors.tsx
+++ b/src/pages/admin/Visitors.tsx
@@ -1,5 +1,19 @@
+import AdminEntryCard from '../../components/common/card/admin/adminEntryCard/AdminEntryCard';
+import ResponsiveLayout from '../../components/common/layout/ResponsiveLayout';
+import * as S from './Visitors.style.ts';
+
 const Visitors = () => {
-  return <div>Visitors</div>;
+  return (
+    <ResponsiveLayout>
+      <S.TitleContainer>
+        <S.Title>입장 현황</S.Title>
+        <S.Description>
+          해당 화면에 얼굴 인식으로 입장한 방문자 수가 표시돼요
+        </S.Description>
+      </S.TitleContainer>
+      <AdminEntryCard />
+    </ResponsiveLayout>
+  );
 };
 
 export default Visitors;

--- a/src/styles/globalStyle.css
+++ b/src/styles/globalStyle.css
@@ -86,11 +86,13 @@ body * {
   --font-title-xl: 600 20px / 1.2 'Pretendard', sans-serif;
   --font-title-xl-2: 600 22px / 1.2 'Pretendard', sans-serif;
   --font-title-xxl: 500 24px / 1.2 'Pretendard', sans-serif;
+  --font-title-xxl-2: 600 28px / 1.2 'Pretendard', sans-serif;
 
   /* body */
   --font-body-s: 400 12px / 1.2 'Pretendard', sans-serif;
   --font-body-m: 400 14px / 1.2 'Pretendard', sans-serif;
   --font-body-l: 400 16px / 1.2 'Pretendard', sans-serif;
+  --font-body-xl: 400 18px / 1.2 'Pretendard', sans-serif;
 
   /* caption */
   --font-caption-s: 400 12px / 1.2 'Pretendard', sans-serif;

--- a/src/styles/globalStyle.css
+++ b/src/styles/globalStyle.css
@@ -84,6 +84,7 @@ body * {
   --font-title-m: 500 16px / 1.2 'Pretendard', sans-serif;
   --font-title-l: 600 16px / 1.2 'Pretendard', sans-serif;
   --font-title-xl: 600 20px / 1.2 'Pretendard', sans-serif;
+  --font-title-xl-2: 600 22px / 1.2 'Pretendard', sans-serif;
   --font-title-xxl: 500 24px / 1.2 'Pretendard', sans-serif;
 
   /* body */


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/86-entry-status` → `dev`

## 📝 작업 내용

- 오른쪽 화살표 아이콘 추가
- Tag 컴포넌트 스타일 수정
  - 화면이 줄어들었을 때 내용이 길면 ... 으로 보여지게 함 
- `globalStyle.css`에 폰트 크기 추가
- 특정 컨퍼런스 조회 api 사용하여 컨퍼런스와 세션 데이터 표시
- 입장 현황 카드 컴포넌트 UI 구현
- 입장 현황 페이지 구현

## 🌠 스크린샷

<img src="https://github.com/user-attachments/assets/10bef4e5-3abd-4a78-b65b-82ab2144b6cf" width="300">
<br />
<img src="https://github.com/user-attachments/assets/5b557765-0857-467a-9bcc-b87624d224e6" width="300">

## ✏️ 후속 작업

## 📌 이슈 번호

- #86 
