### PR TITLE
[FEAT]: 로그인 필드 유효성 검사 및 오류 처리

### DIFF
--- a/src/pages/login/Login.style.ts
+++ b/src/pages/login/Login.style.ts
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 export const PageContainer = styled.div`
@@ -37,4 +38,21 @@ export const ErrorMsg = styled.div`
 export const ButtonContainer = styled.div`
   display: flex;
   margin-top: var(--spacing-8);
+`;
+
+export const TextContainer = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  padding-top: var(--spacing-4);
+`;
+
+export const TxtLabel = styled.label`
+  font: var(--font-body-s);
+  color: ${({ theme }) => theme.colors.typo.tertiary};
+`;
+
+export const StyledLink = styled(Link)`
+  text-decoration: none;
 `;

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -6,20 +6,17 @@ import { getUserData, loginUser } from '../../api/login/login.ts';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../store/useAuthStore.ts';
 import CtaBtn from '../../components/common/button/ctabtn/CtaBtn.tsx';
+import TxtBtn from '../../components/common/button/txtbtn/TxtBtn.tsx';
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
   const { setUserInfo } = useAuthStore();
   const [errorMsg, setErrorMsg] = useState('');
+  const [inputError, setInputError] = useState(false);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (!email.trim() || !password.trim()) {
-      setErrorMsg('이메일 또는 비밀번호를 입력하세요.');
-      return;
-    }
 
     const response = await loginUser({ email, password });
     if (response) {
@@ -29,8 +26,11 @@ export default function Login() {
       navigate(response.role === 'USER' ? '/dashboard' : '/admin/dashboard');
     } else {
       setErrorMsg('이메일 또는 비밀번호를 확인하세요.');
+      setInputError(true);
     }
   };
+
+  const isDisabled = !email.trim() || !password.trim();
 
   return (
     <ResponsiveLayout hasHeader={false}>
@@ -39,14 +39,14 @@ export default function Login() {
         <S.LoginContainer>
           <S.LoginForm onSubmit={handleLogin}>
             <Input
-              state="default"
+              state={inputError ? 'error' : 'default'}
               // type="email"
               placeholder="이메일"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
             />
             <Input
-              state="default"
+              state={inputError ? 'error' : 'default'}
               type="password"
               placeholder="비밀번호"
               value={password}
@@ -56,9 +56,21 @@ export default function Login() {
               {errorMsg && <S.ErrorMsg>{errorMsg}</S.ErrorMsg>}
             </S.ErrorMsgWrapper>
             <S.ButtonContainer>
-              <CtaBtn type="submit">로그인</CtaBtn>
+              <CtaBtn
+                type="submit"
+                variant={isDisabled ? 'tertiary' : 'primary'}
+                disabled={isDisabled}
+              >
+                로그인
+              </CtaBtn>
             </S.ButtonContainer>
           </S.LoginForm>
+          <S.TextContainer>
+            <S.TxtLabel>아직 마스크패스 계정이 없으신가요?</S.TxtLabel>
+            <S.StyledLink to="/signup">
+              <TxtBtn>회원가입하기</TxtBtn>
+            </S.StyledLink>
+          </S.TextContainer>
         </S.LoginContainer>
       </S.PageContainer>
     </ResponsiveLayout>


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/94-login-field-validation` → `dev`

## 📝 작업 내용

- 로그인 필드가 비어 있으면 로그인 버튼 비활성화되고 입력되면 버튼 활성화
- 로그인 실패 시 Input 창에 오류 스타일 적용

## 🌠 스크린샷

<div style="display: flex; justify-content: space-between;">
  <img src="https://github.com/user-attachments/assets/7c784c09-f98d-47e3-9beb-57177e05255d" width="300">
  <img src="https://github.com/user-attachments/assets/56c24285-0f2d-4189-a5a9-00980a2e651a" width="300">
</div>



## ✏️ 후속 작업

## 📌 이슈 번호

- #94 
