### PR TITLE
[FEAT]: 관리자 dashboard 카드 상세 페이지 api 연동

### DIFF
--- a/src/api/admin/conference/getSessionInfo.ts
+++ b/src/api/admin/conference/getSessionInfo.ts
@@ -1,0 +1,10 @@
+import API from '../../axiosIntance';
+
+export const getSessionInfo = async (sessionId: number) => {
+  try {
+    const response = await API.get(`/admin/conference/1/sessions/${sessionId}`);
+    return response.data;
+  } catch (error) {
+    console.log('세션 조회 실패', error);
+  }
+};

--- a/src/components/card/admin/adminSessionCard/AdminSessionCard.style.ts
+++ b/src/components/card/admin/adminSessionCard/AdminSessionCard.style.ts
@@ -24,9 +24,21 @@ export const HeaderContainer = styled.div`
   gap: var(--spacing-8);
 `;
 
+export const TopContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
 export const TagContainer = styled.div`
   display: flex;
   gap: var(--spacing-4);
+`;
+export const DetailBtn = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: transparent;
+  padding: 0;
 `;
 
 export const TitleWrapper = styled.div`

--- a/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
+++ b/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
@@ -2,27 +2,39 @@ import * as S from './AdminSessionCard.style';
 import Profile from '../../profile/Profile';
 import Btn from '../../../common/button/btn/Btn';
 import { Tag } from '../../../common/tag/Tag';
-
+import Icon from '../../../common/icon/Icon';
+import { useNavigate } from 'react-router-dom';
 type AdminSessionCardProps = {
   title: string;
   name: string;
   from: string;
+  id: number;
 };
 
 const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
   title,
   name,
   from,
+  id,
 }) => {
+  const navigate = useNavigate();
   return (
     <S.CardContainer>
       <S.ContentsContainer>
         <S.HeaderContainer>
-          <S.TagContainer>
-            <Tag variant="primary">구역 A</Tag>
-            <Tag variant="secondary">시간</Tag>
-            <Tag variant="secondary">장소</Tag>
-          </S.TagContainer>
+          <S.TopContainer>
+            <S.TagContainer>
+              <Tag variant="secondary">시간</Tag>
+              <Tag variant="secondary">장소</Tag>
+            </S.TagContainer>
+            <S.DetailBtn
+              onClick={() => {
+                navigate(`/admin/conference-info/${id}`);
+              }}
+            >
+              <Icon name="strokeright" color="#909298" size={20} />
+            </S.DetailBtn>
+          </S.TopContainer>
           <S.TitleWrapper>{title}</S.TitleWrapper>
         </S.HeaderContainer>
         <Profile name={name} from={from} />

--- a/src/pages/admin/AdminConferenceInfo.tsx
+++ b/src/pages/admin/AdminConferenceInfo.tsx
@@ -1,0 +1,21 @@
+import { useParams } from 'react-router-dom';
+import { getSessionInfo } from '../../api/admin/conference/getSessionInfo';
+import { useEffect } from 'react';
+const AdminConferenceInfo = () => {
+  const { id } = useParams<{ id: string }>();
+  useEffect(() => {
+    const getInfo = async () => {
+      const sessionId = Number(id);
+      try {
+        const res = await getSessionInfo(sessionId);
+        console.log('resL:', res);
+      } catch (error) {
+        console.log('error:', error);
+      }
+    };
+    getInfo();
+  }, []);
+  return <div>AdminConferenceInfo</div>;
+};
+
+export default AdminConferenceInfo;

--- a/src/pages/admin/ConferenceEdit.tsx
+++ b/src/pages/admin/ConferenceEdit.tsx
@@ -1,5 +1,0 @@
-const ConferenceEdit = () => {
-  return <div>ConferenceEdit</div>;
-};
-
-export default ConferenceEdit;

--- a/src/pages/admin/adminDashboard/AdminDashboard.tsx
+++ b/src/pages/admin/adminDashboard/AdminDashboard.tsx
@@ -3,6 +3,7 @@ import { getConferenceInfo } from '../../../api/admin/conference/getConferenceIn
 import * as S from './AdminDashboard.style';
 import AdminSessionCard from '../../../components/card/admin/adminSessionCard/AdminSessionCard';
 import ResponsiveLayout from '../../../components/common/layout/ResponsiveLayout';
+
 type sessionType = {
   id: number;
   name: string;
@@ -35,7 +36,6 @@ const AdminDashboard = () => {
     fetchConferences();
   }, []);
 
-  //임시 디자인
   return (
     <ResponsiveLayout>
       <S.TitleBox>
@@ -44,8 +44,13 @@ const AdminDashboard = () => {
       </S.TitleBox>
       <S.DataBox>
         {confDatas &&
-          confDatas.map(() => (
-            <AdminSessionCard title="제목" name="이름" from="from" />
+          confDatas.map((data) => (
+            <AdminSessionCard
+              title="제목"
+              name="이름"
+              from="from"
+              id={data.id}
+            />
           ))}
       </S.DataBox>
     </ResponsiveLayout>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,7 +6,7 @@ import ReservationComplete from './pages/reserve/ReservationComplete';
 import SignUp from './pages/login/Signup';
 import UserDashboard from './pages/user/UserDashboard';
 import AdminDashboard from './pages/admin/adminDashboard/AdminDashboard';
-import ConferenceEdit from './pages/admin/ConferenceEdit';
+import AdminConferenceInfo from './pages/admin/AdminConferenceInfo';
 import DeviceConnect from './pages/admin/DeviceConnect';
 import Visitors from './pages/admin/Visitors';
 import VisitorStatus from './pages/admin/VisitorStatus';
@@ -46,7 +46,7 @@ const router = createBrowserRouter([
     element: <PrivateRoute role="ADMIN" />,
     children: [
       { path: 'dashboard', element: <AdminDashboard /> },
-      { path: 'conference-edit', element: <ConferenceEdit /> },
+      { path: 'conference-info', element: <AdminConferenceInfo /> },
       { path: 'device-connect', element: <DeviceConnect /> },
       { path: 'visitors', element: <Visitors /> },
       { path: 'visitor-status', element: <VisitorStatus /> },

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -6,7 +6,7 @@ import ReservationComplete from '../pages/reserve/ReservationComplete';
 import SignUp from '../pages/login/Signup';
 import UserDashboard from '../pages/user/UserDashboard';
 import AdminDashboard from '../pages/admin/adminDashboard/AdminDashboard';
-import ConferenceEdit from '../pages/admin/ConferenceEdit';
+import AdminConferenceInfo from '../pages/admin/AdminConferenceInfo';
 import DeviceConnect from '../pages/admin/DeviceConnect';
 import Visitors from '../pages/admin/Visitors';
 import VisitorStatus from '../pages/admin/VisitorStatus';
@@ -46,7 +46,7 @@ const router = createBrowserRouter([
     element: <PrivateRoute role="ADMIN" />,
     children: [
       { path: 'dashboard', element: <AdminDashboard /> },
-      { path: 'conference-edit', element: <ConferenceEdit /> },
+      { path: 'conference-info/:id', element: <AdminConferenceInfo /> },
       { path: 'device-connect', element: <DeviceConnect /> },
       { path: 'visitors', element: <Visitors /> },
       { path: 'visitor-status', element: <VisitorStatus /> },


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/118-admin-dashboard` → `dev`

## 📝 작업 내용

관리자 dashboard 카드 상세 페이지 api 연동

## 🌠 스크린샷

## ✏️ 후속 작업

## 📌 이슈 번호

- #118 
