### PR TITLE
[FEAT]: 예매자 리스트 페이지 API 연결 및 UI 구현

### DIFF
--- a/src/api/admin/attend/conferenceUserStatus.ts
+++ b/src/api/admin/attend/conferenceUserStatus.ts
@@ -1,0 +1,18 @@
+import API from '../../axiosIntance';
+
+export const getConferenceUserStatus = async (
+  conferenceId: number,
+  sessionId?: number,
+) => {
+  try {
+    const response = await API.get(`/attend/users`, {
+      params: {
+        conferenceId,
+        ...(sessionId && { sessionId }),
+      },
+    });
+    return response.data.data;
+  } catch (error) {
+    console.log('컨퍼런스 참가자 상세 조회 실패', error);
+  }
+};

--- a/src/components/card/admin/adminEntryCard/AdminEntryCard.tsx
+++ b/src/components/card/admin/adminEntryCard/AdminEntryCard.tsx
@@ -18,8 +18,13 @@ export default function AdminEntryCard({ conferInfo }: AdminEntryCardProps) {
   );
   const navigate = useNavigate();
 
-  const handleNavigate = () => {
-    navigate('/admin/visitor-status');
+  const handleNavigate = (conferenceId: number, sessionId?: number) => {
+    navigate('/admin/visitor-status', {
+      state: {
+        conferenceId,
+        sessionId,
+      },
+    });
   };
 
   useEffect(() => {
@@ -44,7 +49,7 @@ export default function AdminEntryCard({ conferInfo }: AdminEntryCardProps) {
           <S.Card>
             <S.CardHeader>
               <S.TotalCount>총 {conferInfo.capacity}명</S.TotalCount>
-              <S.CornerBox onClick={handleNavigate}>
+              <S.CornerBox onClick={() => handleNavigate(conferInfo.id)}>
                 <Icon
                   name="strokeright"
                   color="#909298"
@@ -60,7 +65,9 @@ export default function AdminEntryCard({ conferInfo }: AdminEntryCardProps) {
             <S.Card key={session.id}>
               <S.CardHeader>
                 <S.TotalCount>총 {session.capacity}명</S.TotalCount>
-                <S.CornerBox onClick={handleNavigate}>
+                <S.CornerBox
+                  onClick={() => handleNavigate(conferInfo.id, session.id)}
+                >
                   <Icon
                     name="strokeright"
                     color="#909298"

--- a/src/pages/admin/VisitorStatus.style.ts
+++ b/src/pages/admin/VisitorStatus.style.ts
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+import { media } from '../../styles/breakpoints';
+
+export const TitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+  padding: var(--spacing-24) var(--spacing-20);
+  margin-bottom: var(--spacing-36);
+`;
+
+export const Title = styled.h1`
+  ${media.mobile} {
+    font: var(--font-title-xl-2);
+  }
+
+  ${media.desktop} {
+    font: var(--font-title-xxl-2);
+  }
+
+  ${media.expanded} {
+    font: var(--font-title-xxl-2);
+  }
+`;
+
+export const Description = styled.h2`
+  ${media.mobile} {
+    font: var(--font-body-m);
+    color: ${({ theme }) => theme.colors.typo.tertiary};
+  }
+
+  ${media.desktop} {
+    font: var(--font-body-xl);
+    color: ${({ theme }) => theme.colors.typo.tertiary};
+  }
+
+  ${media.expanded} {
+    font: var(--font-body-xl);
+    color: ${({ theme }) => theme.colors.typo.tertiary};
+  }
+`;
+
+export const FloatingBtnContainer = styled.div`
+  position: fixed;
+  right: var(--spacing-20);
+  bottom: var(--spacing-44);
+  z-index: 1000;
+
+  ${media.desktop} {
+    right: var(--spacing-80);
+  }
+
+  ${media.expanded} {
+    right: calc(var(--spacing-80) * 2);
+  }
+`;
+
+export const TextContainer = styled.span`
+  display: flex;
+  justify-content: end;
+  align-items: center;
+  text-decoration: none;
+  color: ${({ theme }) => theme.colors.typo.secondary};
+`;
+
+export const Line = styled.div`
+  height: 10px;
+  border-right: 1px solid #eeeff0;
+  margin-left: 4px;
+  margin-right: 4px;
+`;

--- a/src/pages/admin/VisitorStatus.tsx
+++ b/src/pages/admin/VisitorStatus.tsx
@@ -1,5 +1,76 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import ResponsiveLayout from '../../components/common/layout/ResponsiveLayout';
+import FloatingBtn from '../../components/common/button/floatingbtn/FloatingBtn';
+import * as S from './VisitorStatus.style.ts';
+import { useEffect, useState } from 'react';
+import { getConferenceUserStatus } from '../../api/admin/attend/conferenceUserStatus.ts';
+import Table from '../../components/common/table/Table.tsx';
+
+interface ConferenceUserStatusData {
+  name: string;
+  capacity: number;
+  attendedCount: number;
+  userAttendances: {
+    userId: number;
+    userName: string;
+    isAttended: boolean;
+  }[];
+}
 const VisitorStatus = () => {
-  return <div>VisitorStatus</div>;
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [userAttend, setUserAttend] = useState<ConferenceUserStatusData | null>(
+    null,
+  );
+
+  const conferInfo = { ...location.state };
+
+  const handleNavigate = () => {
+    navigate('/admin/message-send');
+  };
+
+  useEffect(() => {
+    const fetchUserAttendData = async () => {
+      try {
+        if (conferInfo.sessionId) {
+          const data = await getConferenceUserStatus(
+            conferInfo.conferenceId,
+            conferInfo.sessionId,
+          );
+          setUserAttend(data);
+        } else {
+          const data = await getConferenceUserStatus(conferInfo.conferenceId);
+          setUserAttend(data);
+        }
+      } catch (error) {
+        console.error('데이터 불러오기 실패', error);
+      }
+    };
+    fetchUserAttendData();
+  }, [conferInfo.conferenceId, conferInfo.sessionId]);
+
+  const formattedUserAttend = userAttend?.userAttendances.map((attendance) => ({
+    name: attendance.userName,
+    present: attendance.isAttended,
+  }));
+
+  return (
+    <ResponsiveLayout>
+      <S.TitleContainer>
+        <S.Title>행사명</S.Title>
+        <S.Description>예매자의 참석 여부 데이터를 볼 수 있어요</S.Description>
+      </S.TitleContainer>
+      <S.TextContainer>
+        예약자: {userAttend?.capacity ?? 0}명
+        <S.Line />
+        참석자: {userAttend?.attendedCount ?? 0}명
+      </S.TextContainer>
+      {formattedUserAttend && <Table data={formattedUserAttend} />}
+      <S.FloatingBtnContainer>
+        <FloatingBtn onClick={handleNavigate}>메시지 보내기</FloatingBtn>
+      </S.FloatingBtnContainer>
+    </ResponsiveLayout>
+  );
 };
 
 export default VisitorStatus;

--- a/src/pages/admin/Visitors.style.ts
+++ b/src/pages/admin/Visitors.style.ts
@@ -45,4 +45,12 @@ export const FloatingBtnContainer = styled.div`
   right: var(--spacing-20);
   bottom: var(--spacing-44);
   z-index: 1000;
+
+  ${media.desktop} {
+    right: var(--spacing-80);
+  }
+
+  ${media.expanded} {
+    right: calc(var(--spacing-80) * 2);
+  }
 `;


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/116-reservation-list` → `dev`

## 📝 작업 내용

- 예매자 리스트 페이지를 구현
- API 연동 후 예매자 데이터를 불러와 참석 여부를 "참여" 또는 "미참여"로 표시

## 🌠 스크린샷

https://github.com/user-attachments/assets/408b9807-55fa-434e-8b4a-a6f74f3343ae

## ✏️ 후속 작업

## 📌 이슈 번호

- #116 
