### PR TITLE
Design/100 icon size custom

### DIFF
--- a/src/assets/svg/IcnFillDelete.tsx
+++ b/src/assets/svg/IcnFillDelete.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnFillDelete: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = 'white',
   backgroundColor = '#DDDDDF',
 }) => {

--- a/src/assets/svg/IcnFillEdit.tsx
+++ b/src/assets/svg/IcnFillEdit.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnFillEdit: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnFillSend.tsx
+++ b/src/assets/svg/IcnFillSend.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnFillSend: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#ffffff',
 }) => {
   return (

--- a/src/assets/svg/IcnFillSuccess.tsx
+++ b/src/assets/svg/IcnFillSuccess.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnFillSuccess: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#ffffff',
   backgroundColor = '#414244',
 }) => {

--- a/src/assets/svg/IcnFillWarning.tsx
+++ b/src/assets/svg/IcnFillWarning.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnFillWarning: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = 'white',
   backgroundColor = '#414244',
 }) => {

--- a/src/assets/svg/IcnLogo.tsx
+++ b/src/assets/svg/IcnLogo.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
-const IcnLogo: React.FC<BaseIconProps> = ({ size = 24, color = '#414244' }) => {
+const IcnLogo: React.FC<BaseIconProps> = ({
+  size = '100%',
+  color = '#414244',
+}) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/assets/svg/IcnStrokeBottom.tsx
+++ b/src/assets/svg/IcnStrokeBottom.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokeBottom: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnStrokeCheck.tsx
+++ b/src/assets/svg/IcnStrokeCheck.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokeCheck: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnStrokeClose.tsx
+++ b/src/assets/svg/IcnStrokeClose.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokeClose: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnStrokeEdit.tsx
+++ b/src/assets/svg/IcnStrokeEdit.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokeEdit: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnStrokeFace.tsx
+++ b/src/assets/svg/IcnStrokeFace.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokeFace: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnStrokeLeft.tsx
+++ b/src/assets/svg/IcnStrokeLeft.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokeLeft: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnStrokeMenu.tsx
+++ b/src/assets/svg/IcnStrokeMenu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokeMenu: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnStrokePlus.tsx
+++ b/src/assets/svg/IcnStrokePlus.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokePlus: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnStrokeRight.tsx
+++ b/src/assets/svg/IcnStrokeRight.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokeRight: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnStrokeTop.tsx
+++ b/src/assets/svg/IcnStrokeTop.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokeTop: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/assets/svg/IcnStrokeWarning.tsx
+++ b/src/assets/svg/IcnStrokeWarning.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseIconProps } from '../../components/common/icon/types';
 
 const IcnStrokeWarning: React.FC<BaseIconProps> = ({
-  size = 24,
+  size = '100%',
   color = '#414244',
 }) => {
   return (

--- a/src/components/card/admin/adminEntryCard/AdminEntryCard.tsx
+++ b/src/components/card/admin/adminEntryCard/AdminEntryCard.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import * as S from './AdminEntryCard.style.ts';
 import { Tag } from '../../../common/tag/Tag.tsx';
 import Icon from '../../../common/icon/Icon.tsx';
@@ -11,7 +10,6 @@ interface AdminEntryCardProps {
 }
 
 export default function AdminEntryCard({ conferInfo }: AdminEntryCardProps) {
-  const [isMobile, setIsMobile] = useState<boolean>(false);
   const entryCounts = useSSE(
     conferInfo?.id ?? 0,
     conferInfo?.sessions.map((session) => session.id) ?? [],
@@ -21,19 +19,6 @@ export default function AdminEntryCard({ conferInfo }: AdminEntryCardProps) {
   const handleNavigate = () => {
     navigate('/admin/visitor-status');
   };
-
-  useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth <= 768);
-    };
-
-    checkMobile();
-    window.addEventListener('resize', checkMobile);
-
-    return () => {
-      window.removeEventListener('resize', checkMobile);
-    };
-  }, []);
 
   const sortedSessions = conferInfo?.sessions.sort((a, b) => a.id - b.id);
 
@@ -45,11 +30,7 @@ export default function AdminEntryCard({ conferInfo }: AdminEntryCardProps) {
             <S.CardHeader>
               <S.TotalCount>총 {conferInfo.capacity}명</S.TotalCount>
               <S.CornerBox onClick={handleNavigate}>
-                <Icon
-                  name="strokeright"
-                  color="#909298"
-                  size={isMobile ? 20 : 24}
-                />
+                <Icon name="strokeright" color="#909298" size="mn" />
               </S.CornerBox>
             </S.CardHeader>
             <S.EntryCount>{entryCounts.conferenceAttend}명 입장</S.EntryCount>
@@ -61,11 +42,7 @@ export default function AdminEntryCard({ conferInfo }: AdminEntryCardProps) {
               <S.CardHeader>
                 <S.TotalCount>총 {session.capacity}명</S.TotalCount>
                 <S.CornerBox onClick={handleNavigate}>
-                  <Icon
-                    name="strokeright"
-                    color="#909298"
-                    size={isMobile ? 20 : 24}
-                  />
+                  <Icon name="strokeright" color="#909298" size="mn" />
                 </S.CornerBox>
               </S.CardHeader>
               <S.EntryCount>

--- a/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
+++ b/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
@@ -32,7 +32,7 @@ const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
                 navigate(`/admin/conference-info/${id}`);
               }}
             >
-              <Icon name="strokeright" color="#909298" size={20} />
+              <Icon name="strokeright" color="#909298" size="mn" />
             </S.DetailBtn>
           </S.TopContainer>
           <S.TitleWrapper>{title}</S.TitleWrapper>

--- a/src/components/card/user/faceDataCard/FaceDataCard.tsx
+++ b/src/components/card/user/faceDataCard/FaceDataCard.tsx
@@ -53,7 +53,7 @@ const FaceDataCard: React.FC<FaceDataCardProps> = ({ isFaceExist }) => {
       <S.TextContainer>
         <S.TextWrapper>내 얼굴 정보 관리하기</S.TextWrapper>
         <IcnBtn onClick={handleRegisterFace}>
-          <Icon name="strokeplus" size={20} color={theme.colors.icon.primary} />
+          <Icon name="strokeplus" size="mn" color={theme.colors.icon.primary} />
         </IcnBtn>
       </S.TextContainer>
 
@@ -61,7 +61,7 @@ const FaceDataCard: React.FC<FaceDataCardProps> = ({ isFaceExist }) => {
         <S.MainContentsContainer>
           <Icon
             name="strokeface"
-            size={56}
+            size="xl"
             color={
               isFaceExist
                 ? theme.colors.icon.notice

--- a/src/components/common/button/ctabtn/CtaBtn.tsx
+++ b/src/components/common/button/ctabtn/CtaBtn.tsx
@@ -31,7 +31,7 @@ const CtaBtn: React.FC<CtaBtnProps> = ({
         <>
           {children}
           {icon && (
-            <Icon size={20} name={icon} color={theme.colors.typo.secondary} />
+            <Icon size="mn" name={icon} color={theme.colors.typo.secondary} />
           )}
         </>
       )}

--- a/src/components/common/button/icnbtn/IcnBtn.style.ts
+++ b/src/components/common/button/icnbtn/IcnBtn.style.ts
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 
 export const StyledButton = styled.button`
   display: flex;
-  padding: var(—spacing-0);
+  padding: var(--spacing-0);
   border: none;
-  margin: var(—spacing-0);
+  margin: var(--spacing-0);
 
   width: fit-content;
   height: fit-content;

--- a/src/components/common/checkbox/Checkbox.style.ts
+++ b/src/components/common/checkbox/Checkbox.style.ts
@@ -1,9 +1,32 @@
 import { media } from '../../../styles/breakpoints';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export interface StyledCircleProps {
   variant: 'primary' | 'secondary';
 }
+
+const sizeStyles = {
+  mobile: {
+    primary: css`
+      width: 24px;
+      height: 24px;
+    `,
+    secondary: css`
+      width: 20px;
+      height: 20px;
+    `,
+  },
+  desktop: {
+    primary: css`
+      width: 28px;
+      height: 28px;
+    `,
+    secondary: css`
+      width: 24px;
+      height: 24px;
+    `,
+  },
+};
 
 export const CheckboxContainer = styled.span`
   display: inline-flex;
@@ -21,8 +44,6 @@ export const CheckboxLabel = styled.label`
 
 export const CircleInput = styled.input<StyledCircleProps>`
   appearance: none;
-  width: 24px;
-  height: 24px;
   border-radius: 50%;
   border: ${({ theme }) => `1px solid ${theme.colors.border.primary}`};
   background-color: ${({ theme }) => theme.colors.background.white};
@@ -38,24 +59,20 @@ export const CircleInput = styled.input<StyledCircleProps>`
     border: ${({ theme }) => `1px solid ${theme.colors.icon.notice}`};
   }
 
-  ${media.mobile} {
-    width: 20px;
-    height: 20px;
-  }
+  ${({ variant }) => sizeStyles.mobile[variant]};
 
   ${media.desktop} {
-    width: 24px;
-    height: 24px;
+    ${({ variant }) => sizeStyles.desktop[variant]};
   }
 `;
 
 export const IconWrapper = styled.div`
   position: absolute;
-  top: 20%;
-  left: 30%;
-  width: 100%;
-  height: 100%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   z-index: 1;
+  pointer-events: none;
 `;
 
 export const CheckboxText = styled.span`

--- a/src/components/common/checkbox/Checkbox.style.ts
+++ b/src/components/common/checkbox/Checkbox.style.ts
@@ -66,14 +66,7 @@ export const CircleInput = styled.input<StyledCircleProps>`
   }
 `;
 
-export const IconWrapper = styled.div`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 1;
-  pointer-events: none;
-`;
+export const IconWrapper = styled.div``;
 
 export const CheckboxText = styled.span`
   font: var(--font-body-m);

--- a/src/components/common/checkbox/Checkbox.style.ts
+++ b/src/components/common/checkbox/Checkbox.style.ts
@@ -66,7 +66,14 @@ export const CircleInput = styled.input<StyledCircleProps>`
   }
 `;
 
-export const IconWrapper = styled.div``;
+export const IconWrapper = styled.div`
+  position: absolute;
+  top: 45%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+  pointer-events: none;
+`;
 
 export const CheckboxText = styled.span`
   font: var(--font-body-m);

--- a/src/components/common/checkbox/Checkbox.tsx
+++ b/src/components/common/checkbox/Checkbox.tsx
@@ -1,7 +1,6 @@
 import * as S from './Checkbox.style';
 import Icon from '../icon/Icon';
 import { useTheme } from 'styled-components';
-import { useEffect, useState } from 'react';
 
 export interface CheckboxProps {
   variant?: 'primary' | 'secondary';
@@ -16,28 +15,7 @@ export const Checkbox = ({
   checked = false,
   onChange,
 }: CheckboxProps) => {
-  const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
   const theme = useTheme();
-
-  useEffect(() => {
-    const handleResize = () => {
-      setViewportWidth(window.innerWidth);
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
-
-  const iconSize =
-    viewportWidth <= 768
-      ? variant === 'primary'
-        ? 16
-        : 12
-      : variant === 'primary'
-        ? 20
-        : 16;
 
   return (
     <S.CheckboxContainer>
@@ -49,13 +27,23 @@ export const Checkbox = ({
           checked={checked}
         />
         <S.IconWrapper>
-          <Icon
-            name="strokecheck"
-            size={iconSize}
-            color={
-              checked ? theme.colors.icon.white : theme.colors.icon.secondary
-            }
-          />
+          {variant === 'primary' ? (
+            <Icon
+              name="strokecheck"
+              size="s"
+              color={
+                checked ? theme.colors.icon.white : theme.colors.icon.secondary
+              }
+            />
+          ) : (
+            <Icon
+              name="strokecheck"
+              size="xs"
+              color={
+                checked ? theme.colors.icon.white : theme.colors.icon.secondary
+              }
+            />
+          )}
         </S.IconWrapper>
       </S.CheckboxLabel>
       <S.CheckboxText>{label}</S.CheckboxText>

--- a/src/components/common/footer/Footer.style.ts
+++ b/src/components/common/footer/Footer.style.ts
@@ -21,3 +21,16 @@ export const FooterContainer = styled.footer`
     padding: var(--spacing-16) var(--spacing-80) 52px var(--spacing-80);
   }
 `;
+
+export const FooterWrapper = styled.footer`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  ${media.mobile} {
+  }
+  ${media.desktop} {
+    max-width: 616px;
+  }
+`;

--- a/src/components/common/footer/Footer.tsx
+++ b/src/components/common/footer/Footer.tsx
@@ -6,7 +6,11 @@ interface FooterProps {
 }
 
 const Footer: React.FC<FooterProps> = ({ children }) => {
-  return <S.FooterContainer>{children}</S.FooterContainer>;
+  return (
+    <S.FooterContainer>
+      <S.FooterWrapper>{children}</S.FooterWrapper>
+    </S.FooterContainer>
+  );
 };
 
 export default Footer;

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -23,10 +23,10 @@ export const Header: React.FC<HeaderProps> = ({ icon }) => {
 
   return (
     <S.HeaderContainer>
-      <Icon name="logo" />
+      <Icon name="logo" size="l" />
       {icon && (
         <IcnBtn onClick={openSheet}>
-          <Icon name="strokemenu" size={20} />
+          <Icon name="strokemenu" size="mn" />
         </IcnBtn>
       )}
 

--- a/src/components/common/icon/Icon.style.ts
+++ b/src/components/common/icon/Icon.style.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import { media } from '../../../styles/breakpoints';
+
+const ICON_SIZES = {
+  xs: { mobile: 12, pc: 16 },
+  s: { mobile: 16, pc: 20 },
+  mn: { mobile: 20, pc: 24 },
+  me: { mobile: 20, pc: 32 },
+  l: { mobile: 24, pc: 32 },
+  xl: { mobile: 56, pc: 56 },
+  xxl: { mobile: 102, pc: 102 },
+};
+
+export const ResponsiveIcon = styled.div<{ size: keyof typeof ICON_SIZES }>`
+  ${media.mobile} {
+    width: ${({ size }) => ICON_SIZES[size].mobile}px;
+    height: ${({ size }) => ICON_SIZES[size].mobile}px;
+  }
+
+  ${media.desktop} {
+    width: ${({ size }) => ICON_SIZES[size].pc}px;
+    height: ${({ size }) => ICON_SIZES[size].pc}px;
+  }
+`;

--- a/src/components/common/icon/Icon.tsx
+++ b/src/components/common/icon/Icon.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { IconProps } from './types';
+import * as S from './Icon.style';
 
 // Import all icon components
 import IcnFillDelete from '../../../assets/svg/IcnFillDelete';
@@ -41,7 +42,12 @@ const ICON_COMPONENTS = {
   strokewarning: IcnStrokeWarning,
 };
 
-const Icon: React.FC<IconProps> = ({ name, size, color, backgroundColor }) => {
+const Icon: React.FC<IconProps> = ({
+  name,
+  size = 'mn',
+  color,
+  backgroundColor,
+}) => {
   const IconComponent = ICON_COMPONENTS[name];
 
   if (!IconComponent) {
@@ -50,11 +56,9 @@ const Icon: React.FC<IconProps> = ({ name, size, color, backgroundColor }) => {
   }
 
   return (
-    <IconComponent
-      size={size}
-      color={color}
-      backgroundColor={backgroundColor}
-    />
+    <S.ResponsiveIcon size={size}>
+      <IconComponent color={color} backgroundColor={backgroundColor} />
+    </S.ResponsiveIcon>
   );
 };
 

--- a/src/components/common/icon/types.ts
+++ b/src/components/common/icon/types.ts
@@ -18,7 +18,14 @@ export type IconName =
   | 'strokewarning';
 
 export interface BaseIconProps {
-  size?: number;
+  // size 'xs' => mob: 12, pc: 16
+  // size 's' => mob: 16, pc: 20
+  // size 'mn' => mob: 20, pc: 24 <- medium-normal
+  // size 'me' => mob: 20, pc: 32 <- medium-extraordinary
+  // size 'l' => mob: 24, pc: 32
+  // size 'xl' => mob: 56, pc: 56
+  // size 'xxl' => mob: 102, pc: 102
+  size?: 'xs' | 's' | 'mn' | 'me' | 'l' | 'xl' | 'xxl';
   color?: string;
   backgroundColor?: string;
 }

--- a/src/components/common/notify/Notify.tsx
+++ b/src/components/common/notify/Notify.tsx
@@ -22,14 +22,14 @@ const Notify: React.FC<NotifyProps> = ({
     <S.NotifyContainer onClick={onClick}>
       <S.TextWrapper>
         <Icon
-          size={24}
+          size="l"
           name={icon}
           color={color}
           backgroundColor={backgroundColor}
         />
         아직 얼굴 데이터가 등록되지 않았어요!
       </S.TextWrapper>
-      <Icon name="strokeright" size={16} color={theme.colors.icon.secondary} />
+      <Icon name="strokeright" size="s" color={theme.colors.icon.secondary} />
     </S.NotifyContainer>
   );
 };

--- a/src/components/common/popup/Popup.tsx
+++ b/src/components/common/popup/Popup.tsx
@@ -24,7 +24,7 @@ const Popup: React.FC<PopupProps> = ({ type, onContinue, onClose }) => {
           {icon && (
             <Icon
               name="strokeface"
-              size={56}
+              size="xl"
               color={theme.colors.icon.notice}
             />
           )}

--- a/src/components/common/toast/Toast.tsx
+++ b/src/components/common/toast/Toast.tsx
@@ -17,7 +17,7 @@ export const Toast = ({ state = 'default', children }: ToastProps) => {
         <S.Toast state={state}>
           <Icon
             name="fillwarning"
-            size={20}
+            size="mn"
             color={theme.colors.icon.error}
             backgroundColor={theme.colors.icon.white}
           />
@@ -27,7 +27,7 @@ export const Toast = ({ state = 'default', children }: ToastProps) => {
         <S.Toast state={state}>
           <Icon
             name="fillsuccess"
-            size={20}
+            size="mn"
             color={theme.colors.icon.primary}
             backgroundColor={theme.colors.icon.white}
           />


### PR DESCRIPTION
## 🚀 반영 브랜치
`design/100-icon-size-custom` → `dev`

## 📝 작업 내용

- Checkbox.tsx 컴포넌트를 디자인에 맞게 제작하였습니다.
![스크린샷 2025-03-26 오전 10 31 32](https://github.com/user-attachments/assets/8c7e2df5-0d83-4864-8918-1c418d5a8994)
![스크린샷 2025-03-26 오전 10 31 48](https://github.com/user-attachments/assets/408433ef-c4c9-4706-a030-69ae293b24e0)
-> 각각 모바일 / PC 환경

- Footer 컴포넌트의 max-width를 지정해주었습니다.
- Icon 컴포넌트의 사이즈를 체계화하고 이를 적용시켰습니다. (추후 디자이너와 상의해야함)
![스크린샷 2025-03-26 오전 10 33 39](https://github.com/user-attachments/assets/12e8ed64-f23c-4d21-a990-68dc70326647)

## 🌠 스크린샷

## ✏️ 후속 작업

## 📌 이슈 번호

- #100 
