### PR TITLE
[FEAT]:관리자 dashboard 데이터 렌더링, 기기연동 및 비활성화

### DIFF
--- a/src/api/admin/active/setActiveState.ts
+++ b/src/api/admin/active/setActiveState.ts
@@ -1,0 +1,10 @@
+import API from '../../axiosIntance';
+
+export const setActiveState = async (sessionId: number) => {
+  try {
+    const response = await API.put(`/admin/conference/1/sessions/${sessionId}`);
+    return response.data;
+  } catch (error) {
+    console.log('세션 상태 변경 실패', error);
+  }
+};

--- a/src/api/admin/qrcode/qrcode.ts
+++ b/src/api/admin/qrcode/qrcode.ts
@@ -1,16 +1,16 @@
 import API from '../../axiosIntance';
 
-export const getQRCode = async () => {
+export const getQRCode = async (conferenceId: string, sessionId: string) => {
   try {
     const response = await API.get('/admin/qr', {
       params: {
-        conferenceId: 1,
-        sessionId: 1,
+        conferenceId,
+        sessionId,
         url: 'https://maskpass-6zo.vercel.app/face-recognition',
       },
     });
 
-    return response.data;
+    return response.data.data;
   } catch (error) {
     console.log('QR 생성 실패', error);
   }

--- a/src/components/card/admin/adminSessionCard/AdminSessionCard.style.ts
+++ b/src/components/card/admin/adminSessionCard/AdminSessionCard.style.ts
@@ -1,4 +1,7 @@
 import styled from 'styled-components';
+interface CardContainerProps {
+  $isActive: boolean;
+}
 
 export const CardContainer = styled.div`
   display: flex;
@@ -12,10 +15,11 @@ export const CardContainer = styled.div`
   width: 100%;
 `;
 
-export const ContentsContainer = styled.div`
+export const ContentsContainer = styled.div<CardContainerProps>`
   display: flex;
   flex-direction: column;
   gap: var(--spacing-8);
+  opacity: ${({ $isActive }) => ($isActive ? 1 : 0.4)};
 `;
 
 export const HeaderContainer = styled.div`

--- a/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
+++ b/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
@@ -6,9 +6,11 @@ import Icon from '../../../common/icon/Icon';
 import { useNavigate } from 'react-router-dom';
 type AdminSessionCardProps = {
   title: string;
-  name: string;
-  from: string;
+  name: string | null;
+  from: string | null;
   id: number;
+  date: string;
+  location: string;
 };
 
 const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
@@ -16,6 +18,8 @@ const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
   name,
   from,
   id,
+  location,
+  date,
 }) => {
   const navigate = useNavigate();
   return (
@@ -24,8 +28,8 @@ const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
         <S.HeaderContainer>
           <S.TopContainer>
             <S.TagContainer>
-              <Tag variant="secondary">시간</Tag>
-              <Tag variant="secondary">장소</Tag>
+              <Tag variant="tertiary">{date}</Tag>
+              <Tag variant="tertiary">{location}</Tag>
             </S.TagContainer>
             <S.DetailBtn
               onClick={() => {

--- a/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
+++ b/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
@@ -6,6 +6,7 @@ import Icon from '../../../common/icon/Icon';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { setActiveState } from '../../../../api/admin/active/setActiveState';
+import { useTheme } from 'styled-components';
 type AdminSessionCardProps = {
   title: string;
   name: string | null;
@@ -26,12 +27,11 @@ const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
   isActive,
 }) => {
   const navigate = useNavigate();
-  const [_active, _setActive] = useState(isActive);
-
-  const setActive = async () => {
+  const [active, setActive] = useState(isActive);
+  const handleActive = async () => {
     try {
       const res = await setActiveState(id);
-
+      setActive((prev) => !prev);
       console.log('regg:', res);
     } catch (error) {
       console.log('error', error);
@@ -39,7 +39,7 @@ const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
   };
   return (
     <S.CardContainer>
-      <S.ContentsContainer>
+      <S.ContentsContainer $isActive={active}>
         <S.HeaderContainer>
           <S.TopContainer>
             <S.TagContainer>
@@ -50,6 +50,7 @@ const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
               onClick={() => {
                 navigate(`/admin/conference-info/${id}`);
               }}
+              disabled={!active}
             >
               <Icon name="strokeright" color="#909298" size="mn" />
             </S.DetailBtn>
@@ -60,12 +61,17 @@ const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
       </S.ContentsContainer>
 
       <S.BtnContainer>
-        <Btn variant="secondary" state="default" onClick={() => setActive()}>
-          비활성화
+        <Btn
+          variant={active ? 'tertiary' : 'primary'}
+          state="default"
+          onClick={() => handleActive()}
+          isBlue={!active}
+        >
+          {active ? '비활성화' : '활성화'}
         </Btn>
         <Btn
           variant="primary"
-          state="default"
+          state={active ? 'default' : 'disabled'}
           onClick={() => {
             navigate(`/admin/device-connect?conferenceId=1&sessionId=${id}`);
           }}

--- a/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
+++ b/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
@@ -4,6 +4,8 @@ import Btn from '../../../common/button/btn/Btn';
 import { Tag } from '../../../common/tag/Tag';
 import Icon from '../../../common/icon/Icon';
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { setActiveState } from '../../../../api/admin/active/setActiveState';
 type AdminSessionCardProps = {
   title: string;
   name: string | null;
@@ -11,6 +13,7 @@ type AdminSessionCardProps = {
   id: number;
   date: string;
   location: string;
+  isActive: boolean;
 };
 
 const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
@@ -20,8 +23,20 @@ const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
   id,
   location,
   date,
+  isActive,
 }) => {
   const navigate = useNavigate();
+  const [_active, _setActive] = useState(isActive);
+
+  const setActive = async () => {
+    try {
+      const res = await setActiveState(id);
+
+      console.log('regg:', res);
+    } catch (error) {
+      console.log('error', error);
+    }
+  };
   return (
     <S.CardContainer>
       <S.ContentsContainer>
@@ -45,10 +60,16 @@ const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
       </S.ContentsContainer>
 
       <S.BtnContainer>
-        <Btn variant="secondary" state="default">
+        <Btn variant="secondary" state="default" onClick={() => setActive()}>
           비활성화
         </Btn>
-        <Btn variant="primary" state="default">
+        <Btn
+          variant="primary"
+          state="default"
+          onClick={() => {
+            navigate(`/admin/device-connect?conferenceId=1&sessionId=${id}`);
+          }}
+        >
           기기연결
         </Btn>
       </S.BtnContainer>

--- a/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
+++ b/src/components/card/admin/adminSessionCard/AdminSessionCard.tsx
@@ -6,7 +6,6 @@ import Icon from '../../../common/icon/Icon';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { setActiveState } from '../../../../api/admin/active/setActiveState';
-import { useTheme } from 'styled-components';
 type AdminSessionCardProps = {
   title: string;
   name: string | null;
@@ -57,7 +56,7 @@ const AdminSessionCard: React.FC<AdminSessionCardProps> = ({
           </S.TopContainer>
           <S.TitleWrapper>{title}</S.TitleWrapper>
         </S.HeaderContainer>
-        <Profile name={name} from={from} />
+        {name && <Profile name={name} from={from} />}
       </S.ContentsContainer>
 
       <S.BtnContainer>

--- a/src/components/card/profile/Profile.tsx
+++ b/src/components/card/profile/Profile.tsx
@@ -1,8 +1,8 @@
 import * as S from './Profile.style';
 
 type ProfileProps = {
-  name: string;
-  from: string;
+  name: string | null;
+  from: string | null;
 };
 
 const Profile: React.FC<ProfileProps> = ({ name, from }) => {

--- a/src/components/common/button/btn/Btn.style.ts
+++ b/src/components/common/button/btn/Btn.style.ts
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 
 interface StyledButtonProps {
-  variant: 'primary' | 'secondary' | 'tertiary' | 'quaternary';
+  variant: 'primary' | 'secondary' | 'tertiary' | 'quaternary' | 'blue';
   state: 'default' | 'disabled';
+  isBlue?: boolean;
 }
 
 export const StyledButton = styled.button<StyledButtonProps>`
@@ -13,15 +14,18 @@ export const StyledButton = styled.button<StyledButtonProps>`
   padding: var(--spacing-8) var(--spacing-0);
   font: var(--font-title-s);
   border-radius: var(--radius-8);
-
   height: fit-content;
   width: 89px;
 
-  ${({ theme, variant }) => {
+  ${({ theme, variant, isBlue }) => {
     switch (variant) {
       case 'primary':
         return `
-          background-color: ${theme.colors.background.tertiary};
+              background-color: ${
+                isBlue
+                  ? theme.colors.background.primary
+                  : theme.colors.background.tertiary
+              };
           color: ${theme.colors.typo.white};
           border: none;
 
@@ -70,6 +74,7 @@ export const StyledButton = styled.button<StyledButtonProps>`
             color: ${theme.colors.typo.primary};
           }
         `;
+
       default:
         return '';
     }

--- a/src/components/common/button/btn/Btn.tsx
+++ b/src/components/common/button/btn/Btn.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import * as S from './Btn.style';
 
 type BtnProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: 'primary' | 'secondary' | 'tertiary' | 'quaternary';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'quaternary' | 'blue';
   state?: 'default' | 'disabled';
+  isBlue?: boolean;
   children: React.ReactNode;
 };
 
@@ -11,6 +12,7 @@ const Btn: React.FC<BtnProps> = ({
   variant = 'primary',
   state = 'default',
   children,
+  isBlue,
   ...props
 }) => {
   return (
@@ -18,6 +20,7 @@ const Btn: React.FC<BtnProps> = ({
       variant={variant}
       state={state}
       disabled={state === 'disabled'}
+      isBlue={isBlue}
       {...props}
     >
       {children}

--- a/src/components/common/img/Img.tsx
+++ b/src/components/common/img/Img.tsx
@@ -4,6 +4,7 @@ import * as S from './Img.style';
 type ImgProps = {
   size: 294 | 168 | 140 | 128 | 100 | 80 | 68;
   imageUrl?: string;
+  alt?: string;
 };
 
 const Img: React.FC<ImgProps> = ({ size, imageUrl }) => {

--- a/src/components/common/tag/Tag.style.ts
+++ b/src/components/common/tag/Tag.style.ts
@@ -21,13 +21,13 @@ export const Tag = styled.span<TagProps>`
         `;
       case 'secondary':
         return `
-          background-color: ${theme.colors.background.secondary};
-          color: ${theme.colors.typo.primary};
+          background-color: ${theme.colors.background.tertiary};
+          color: ${theme.colors.typo.white};
         `;
       case 'tertiary':
         return `
-          background-color: ${theme.colors.background.tertiary};
-          color: ${theme.colors.typo.white};
+          background-color: ${theme.colors.background.secondary};
+          color: ${theme.colors.typo.primary};
         `;
     }
   }};

--- a/src/pages/admin/DeviceConnect.style.ts
+++ b/src/pages/admin/DeviceConnect.style.ts
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+export const TitleBox = styled.div`
+  padding: var(--spacing-20) 0;
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: var(--spacing-4);
+`;
+export const Title = styled.h1`
+  text-align: center;
+  color: ${({ theme }) => theme.colors.typo.primary};
+  font-weight: 600;
+  font-size: 22px;
+`;
+export const SubTitle = styled.div`
+  color: ${({ theme }) => theme.colors.typo.tertiary};
+`;
+
+export const QRContainer = styled.div`
+  padding: 0 var(--spacing-20);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/pages/admin/DeviceConnect.tsx
+++ b/src/pages/admin/DeviceConnect.tsx
@@ -1,33 +1,57 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { getQRCode } from '../../api/admin/qrcode/qrcode';
+import { useSearchParams } from 'react-router-dom';
+import ResponsiveLayout from '../../components/common/layout/ResponsiveLayout';
+import * as S from './DeviceConnect.style';
+
+//components
+import Img from '../../components/common/img/Img';
 const DeviceConnect = () => {
   const [qrCode, setQrCode] = useState<string | null>(null);
+  const [searchParams] = useSearchParams();
 
-  const getQR = async () => {
-    try {
-      const result = await getQRCode();
-      console.log('QR 생성 성공:', result.qrImageBase64);
-      setQrCode(result.qrImageBase64);
-    } catch (error) {
-      alert('QR 코드 생성 실패. 다시 시도해주세요.');
-    }
-  };
+  const conferenceId = searchParams.get('conferenceId');
+  const sessionId = searchParams.get('sessionId');
+  console.log(conferenceId, sessionId);
+  useEffect(() => {
+    const getQR = async () => {
+      if (!conferenceId || !sessionId) {
+        alert('잘못된 접근입니다.');
+        return;
+      }
+      try {
+        const result = await getQRCode(conferenceId, sessionId);
+        console.log('QR 생성 성공:', result.qrImageBase64);
+        setQrCode(result.qrImageBase64);
+      } catch (error) {
+        alert('QR 코드 생성 실패. 다시 시도해주세요.');
+      }
+    };
+    getQR();
+  }, []);
 
   return (
-    <div
-      style={{
-        padding: '10px',
-        display: 'flex',
-        flexDirection: 'column',
-        width: '300px',
-        alignItems: 'center',
-      }}
-    >
-      {qrCode && <img src={qrCode} alt="QR Code" width={256} height={256} />}
-      <button onClick={getQR} style={{ width: '100px' }}>
-        기기 연동
-      </button>
-    </div>
+    <ResponsiveLayout>
+      <S.Container>
+        <S.TitleBox>
+          <S.Title>기기 연결</S.Title>
+          <S.SubTitle>
+            현장에서 사용할 기기를 화면에 표시된 QR로 연결하세요
+          </S.SubTitle>
+        </S.TitleBox>
+        <S.QRContainer
+          style={{
+            padding: '10px',
+            display: 'flex',
+            flexDirection: 'column',
+            width: '300px',
+            alignItems: 'center',
+          }}
+        >
+          {qrCode && <Img imageUrl={qrCode} alt="QR Code" size={294} />}
+        </S.QRContainer>
+      </S.Container>
+    </ResponsiveLayout>
   );
 };
 

--- a/src/pages/admin/adminDashboard/AdminDashboard.tsx
+++ b/src/pages/admin/adminDashboard/AdminDashboard.tsx
@@ -3,7 +3,7 @@ import { getConferenceInfo } from '../../../api/admin/conference/getConferenceIn
 import * as S from './AdminDashboard.style';
 import AdminSessionCard from '../../../components/card/admin/adminSessionCard/AdminSessionCard';
 import ResponsiveLayout from '../../../components/common/layout/ResponsiveLayout';
-
+import { formatTimeRange } from '../../../utils/time/timeFormat';
 type sessionType = {
   id: number;
   name: string;
@@ -13,6 +13,7 @@ type sessionType = {
   capacity: number;
   hasSessions: boolean;
   endTime: string;
+  startTime: string;
   conferenceId: number;
   speakerImage: string | null;
   speakerName: string | null;
@@ -44,14 +45,27 @@ const AdminDashboard = () => {
       </S.TitleBox>
       <S.DataBox>
         {confDatas &&
-          confDatas.map((data) => (
-            <AdminSessionCard
-              title="제목"
-              name="이름"
-              from="from"
-              id={data.id}
-            />
-          ))}
+          confDatas.map((data) => {
+            const {
+              id,
+              name,
+              endTime,
+              startTime,
+              speakerName,
+              speakerOrganization,
+              location,
+            } = data;
+            return (
+              <AdminSessionCard
+                title={name}
+                date={formatTimeRange(startTime, endTime)}
+                name={speakerName}
+                from={speakerOrganization}
+                id={id}
+                location={location}
+              />
+            );
+          })}
       </S.DataBox>
     </ResponsiveLayout>
   );

--- a/src/pages/admin/adminDashboard/AdminDashboard.tsx
+++ b/src/pages/admin/adminDashboard/AdminDashboard.tsx
@@ -18,6 +18,7 @@ type sessionType = {
   speakerImage: string | null;
   speakerName: string | null;
   speakerOrganization: string | null;
+  active: boolean;
 };
 
 const AdminDashboard = () => {
@@ -54,6 +55,7 @@ const AdminDashboard = () => {
               speakerName,
               speakerOrganization,
               location,
+              active,
             } = data;
             return (
               <AdminSessionCard
@@ -63,6 +65,7 @@ const AdminDashboard = () => {
                 from={speakerOrganization}
                 id={id}
                 location={location}
+                isActive={active}
               />
             );
           })}

--- a/src/pages/admin/adminDashboard/AdminDashboard.tsx
+++ b/src/pages/admin/adminDashboard/AdminDashboard.tsx
@@ -28,7 +28,6 @@ const AdminDashboard = () => {
     const fetchConferences = async () => {
       try {
         const res = await getConferenceInfo(1);
-        console.log('컨퍼런스 데이터:', res);
         setConfDatas(res.sessions);
       } catch (error) {
         console.error('컨퍼런스 데이터 조회 실패', error);


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/main` → `develop`

## 📝 작업 내용

- 관리자 dashboard 세션 카드 데이터 연동
- 기기 연동 라우팅
- 비활성화 기능 api 연동 및 상태값 변경

## 🌠 스크린샷
<img width="347" alt="스크린샷 2025-03-26 오후 3 35 24" src="https://github.com/user-attachments/assets/d94832a8-b10e-4d64-973c-31d05d22b9b0" />



## ✏️ 후속 작업

## 📌 이슈 번호

- #121 
