### PR TITLE
[DESIGN] Admin 페이지 Header에서 Sheet 나오도록 수정

### DIFF
--- a/src/components/common/sheet/Sheet.tsx
+++ b/src/components/common/sheet/Sheet.tsx
@@ -15,8 +15,10 @@ interface SheetProps {
 const Sheet: React.FC<SheetProps> = ({ isOpen, onClose }) => {
   const location = useLocation();
   const navigate = useNavigate();
-
   const currentPath = location.pathname;
+
+  // ✅ /admin 포함 여부로 구분
+  const isAdmin = currentPath.startsWith('/admin');
 
   const handleLogout = async () => {
     const response = await logoutUser();
@@ -37,20 +39,40 @@ const Sheet: React.FC<SheetProps> = ({ isOpen, onClose }) => {
             <Icon name="strokeclose" />
           </IcnBtn>
         </S.CloseButtonWrapper>
+
         <S.ContentsWrapper>
           <S.ButtonWrapper>
-            <SheetBtn
-              onClick={() => navigate('/dashboard')}
-              state={currentPath === '/profile' ? 'off' : 'on'}
-            >
-              홈
-            </SheetBtn>
-            <SheetBtn
-              state={currentPath === '/profile' ? 'on' : 'off'}
-              onClick={() => navigate('/profile')}
-            >
-              나의 정보
-            </SheetBtn>
+            {isAdmin ? (
+              <>
+                <SheetBtn
+                  onClick={() => navigate('/admin/dashboard')}
+                  state={currentPath === '/admin/dashboard' ? 'on' : 'off'}
+                >
+                  행사 목록
+                </SheetBtn>
+                <SheetBtn
+                  state={currentPath === '/admin/visitors' ? 'on' : 'off'}
+                  onClick={() => navigate('/admin/visitors')}
+                >
+                  입장 현황
+                </SheetBtn>
+              </>
+            ) : (
+              <>
+                <SheetBtn
+                  onClick={() => navigate('/dashboard')}
+                  state={currentPath === '/dashboard' ? 'on' : 'off'}
+                >
+                  홈
+                </SheetBtn>
+                <SheetBtn
+                  state={currentPath === '/profile' ? 'on' : 'off'}
+                  onClick={() => navigate('/profile')}
+                >
+                  나의 정보
+                </SheetBtn>
+              </>
+            )}
           </S.ButtonWrapper>
 
           <S.BottomButtonWrapper>

--- a/src/pages/admin/MessageSend.style.ts
+++ b/src/pages/admin/MessageSend.style.ts
@@ -14,6 +14,11 @@ export const TitleContainer = styled.div`
   }
 `;
 
+export const PageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 export const Title = styled.h1`
   font: var(--font-title-xl-2);
 

--- a/src/pages/admin/MessageSend.tsx
+++ b/src/pages/admin/MessageSend.tsx
@@ -143,96 +143,100 @@ const MessageSend = () => {
   };
 
   return (
-    <ResponsiveLayout>
-      <S.TitleContainer>
-        <S.Title>메시지 전송</S.Title>
-      </S.TitleContainer>
-      <Notify
-        icon="fillwarning"
-        color={theme.colors.icon.white}
-        backgroundColor={theme.colors.icon.notice}
-      >
-        작성하신 내용은 문자 메세지로 전송됩니다.
-      </Notify>
-      <form onSubmit={handleSubmit}>
-        <S.CardContainer>
-          <AdminSessionMessageCard
-            id={conferenceDataQuery.data?.id ?? 0}
-            title={conferenceDataQuery.data?.name ?? ''}
-            date={`${conferenceDataQuery.data?.startTime} - ${conferenceDataQuery.data?.endTime}`}
-            location={conferenceDataQuery.data?.location ?? ''}
-            selected={selectedConferences.includes(
-              conferenceDataQuery.data?.id ?? -1,
-            )}
-            onClick={() =>
-              handleConferenceClick(conferenceDataQuery.data?.id ?? -1)
-            }
-          />
-          {conferenceDataQuery?.data?.sessions?.map((data) => (
+    <ResponsiveLayout hasFooter={true}>
+      <S.PageContainer>
+        <S.TitleContainer>
+          <S.Title>메시지 전송</S.Title>
+        </S.TitleContainer>
+        <Notify
+          icon="fillwarning"
+          color={theme.colors.icon.white}
+          backgroundColor={theme.colors.icon.notice}
+        >
+          작성하신 내용은 문자 메세지로 전송됩니다.
+        </Notify>
+        <form onSubmit={handleSubmit}>
+          <S.CardContainer>
             <AdminSessionMessageCard
-              key={data.id}
-              title={data.name}
-              name={data.speakerName}
-              from={data.speakerOrganization}
-              id={data.id}
-              date={`${data.startTime} - ${data.endTime}`}
-              location={data.location}
-              selected={selectedSessions.includes(data.id)}
-              onClick={() => handleSessionClick(data.id)}
-            />
-          ))}
-        </S.CardContainer>
-        <S.Destination>
-          <S.DestinationLabel>발송 대상</S.DestinationLabel>
-          {checkboxes.map(({ key, label }) => (
-            <Checkbox
-              key={key}
-              checked={checkedItems.includes(key)}
-              onChange={() =>
-                key === 'all' ? handleAllCheckbox() : handleSingleCheckbox(key)
+              id={conferenceDataQuery.data?.id ?? 0}
+              title={conferenceDataQuery.data?.name ?? ''}
+              date={`${conferenceDataQuery.data?.startTime} - ${conferenceDataQuery.data?.endTime}`}
+              location={conferenceDataQuery.data?.location ?? ''}
+              selected={selectedConferences.includes(
+                conferenceDataQuery.data?.id ?? -1,
+              )}
+              onClick={() =>
+                handleConferenceClick(conferenceDataQuery.data?.id ?? -1)
               }
-              label={label}
             />
-          ))}
-        </S.Destination>
-        <Textarea
-          placeholder="내용을 입력하세요"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-        />
-        <S.ImgContainer>
-          <S.BtnBox>
-            <S.StyledBtn
-              variant="secondary"
-              state="default"
-              type="button"
-              onClick={handleClick}
-            >
-              이미지 추가
-              <input
-                type="file"
-                key={preview || 'new'}
-                ref={fileInputRef}
-                accept="image/*"
-                onChange={handleFileChange}
-                style={{ display: 'none' }}
+            {conferenceDataQuery?.data?.sessions?.map((data) => (
+              <AdminSessionMessageCard
+                key={data.id}
+                title={data.name}
+                name={data.speakerName}
+                from={data.speakerOrganization}
+                id={data.id}
+                date={`${data.startTime} - ${data.endTime}`}
+                location={data.location}
+                selected={selectedSessions.includes(data.id)}
+                onClick={() => handleSessionClick(data.id)}
               />
-            </S.StyledBtn>
-            <S.BtnDescription>최대 1개까지 가능합니다</S.BtnDescription>
-          </S.BtnBox>
-          {preview && (
-            <S.ImgBox>
-              <S.CloseBtn onClick={handleImageDelete}>
-                <Icon name="strokeclose" size="s" />
-              </S.CloseBtn>
-              <Img imageUrl={preview} size={128} />
-            </S.ImgBox>
-          )}
-        </S.ImgContainer>
-        <Footer>
-          <CtaBtn type="submit">전송하기</CtaBtn>
-        </Footer>
-      </form>
+            ))}
+          </S.CardContainer>
+          <S.Destination>
+            <S.DestinationLabel>발송 대상</S.DestinationLabel>
+            {checkboxes.map(({ key, label }) => (
+              <Checkbox
+                key={key}
+                checked={checkedItems.includes(key)}
+                onChange={() =>
+                  key === 'all'
+                    ? handleAllCheckbox()
+                    : handleSingleCheckbox(key)
+                }
+                label={label}
+              />
+            ))}
+          </S.Destination>
+          <Textarea
+            placeholder="내용을 입력하세요"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+          <S.ImgContainer>
+            <S.BtnBox>
+              <S.StyledBtn
+                variant="secondary"
+                state="default"
+                type="button"
+                onClick={handleClick}
+              >
+                이미지 추가
+                <input
+                  type="file"
+                  key={preview || 'new'}
+                  ref={fileInputRef}
+                  accept="image/*"
+                  onChange={handleFileChange}
+                  style={{ display: 'none' }}
+                />
+              </S.StyledBtn>
+              <S.BtnDescription>최대 1개까지 가능합니다</S.BtnDescription>
+            </S.BtnBox>
+            {preview && (
+              <S.ImgBox>
+                <S.CloseBtn onClick={handleImageDelete}>
+                  <Icon name="strokeclose" size="s" />
+                </S.CloseBtn>
+                <Img imageUrl={preview} size={128} />
+              </S.ImgBox>
+            )}
+          </S.ImgContainer>
+          <Footer>
+            <CtaBtn type="submit">전송하기</CtaBtn>
+          </Footer>
+        </form>
+      </S.PageContainer>
     </ResponsiveLayout>
   );
 };

--- a/src/pages/admin/Visitors.tsx
+++ b/src/pages/admin/Visitors.tsx
@@ -18,7 +18,7 @@ const Visitors = () => {
   }
 
   return (
-    <ResponsiveLayout>
+    <ResponsiveLayout hasHeaderIcon={true}>
       <S.TitleContainer>
         <S.Title>입장 현황</S.Title>
         <S.Description>

--- a/src/pages/admin/adminDashboard/AdminDashboard.tsx
+++ b/src/pages/admin/adminDashboard/AdminDashboard.tsx
@@ -40,7 +40,7 @@ const AdminDashboard = () => {
   }, []);
 
   return (
-    <ResponsiveLayout>
+    <ResponsiveLayout hasHeaderIcon={true}>
       <S.TitleBox>
         <S.Title>행사 목록</S.Title>
         <S.SubTitle>얼굴 인증으로 입출입을 관리하는 행사 목록이에요</S.SubTitle>


### PR DESCRIPTION
## 🚀 반영 브랜치
`design/147-admin-header-sheet` → `dev`

## 📝 작업 내용
- AdminDashboard, Visitors 페이지에서 Header 내에 우측 아이콘이 보이게 설정하였습니다.
- 아이콘 클릭 시 라우트를 통해 해당 페이지로 이동할 수 있게 설정하였습니다.
- MessageSend 페이지에서 스크롤이 가능하도록 설정하였습니다.

## 🌠 스크린샷

## ✏️ 후속 작업

## 📌 이슈 번호

- #147 
