### PR TITLE
[DESIGN]: Header, ResponsiveLayout 컴포넌트 등 스타일 수정

### DIFF
--- a/src/components/card/user/faceDataCard/FaceDataCard.style.ts
+++ b/src/components/card/user/faceDataCard/FaceDataCard.style.ts
@@ -35,7 +35,7 @@ export const TextWrapper = styled.div`
 export const ContentsContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-end;
   align-items: center;
   gap: var(--spacing-20);
   height: 168px;

--- a/src/components/common/input/Input.style.ts
+++ b/src/components/common/input/Input.style.ts
@@ -22,6 +22,7 @@ export const StyledInput = styled.input<InputProps>`
   outline: none;
   padding: var(--spacing-16) var(--spacing-4);
   background-color: transparent;
+  border-radius: 0px;
   &:focus {
     border-bottom: 1px solid
       ${({ theme }) => theme.colors.border.primaryPressed};


### PR DESCRIPTION
## 🚀 반영 브랜치
`design/149-user-flow-style` → `dev`

## 📝 작업 내용
- Header에 border-bottom을 집어넣었습니다.
- ResponsiveLayout에 반응형 Header의 높이만큼의 margin을 집어넣었습니다.
- FaceDataCard를 UI에 맞게 수정하였습니다.

## 🌠 스크린샷

## ✏️ 후속 작업

## 📌 이슈 번호

- #149 
