### PR TITLE
[FIX]: 얼굴 삭제 후 유저 데이터 자동 갱신 

### DIFF
--- a/src/api/face/faceDelete.ts
+++ b/src/api/face/faceDelete.ts
@@ -7,5 +7,6 @@ export const faceDelete = async () => {
     return response.data.data;
   } catch (error) {
     console.log('등록한 얼굴 삭제 실패', error);
+    throw new Error('Face deletion failed');
   }
 };

--- a/src/components/card/admin/adminSessionCard/AdminSessionCard.style.ts
+++ b/src/components/card/admin/adminSessionCard/AdminSessionCard.style.ts
@@ -13,6 +13,7 @@ export const CardContainer = styled.div`
   border-radius: var(--radius-12);
   background-color: ${({ theme }) => theme.colors.background.white};
   width: 100%;
+  user-select: none;
 `;
 
 export const ContentsContainer = styled.div<CardContainerProps>`
@@ -43,6 +44,7 @@ export const DetailBtn = styled.button`
   border: none;
   background-color: transparent;
   padding: 0;
+  cursor: pointer;
 `;
 
 export const TitleWrapper = styled.div`

--- a/src/components/card/user/faceDataCard/FaceDataCard.tsx
+++ b/src/components/card/user/faceDataCard/FaceDataCard.tsx
@@ -2,8 +2,6 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 import { useAuthStore } from '../../../../store/useAuthStore';
-
-import { getUserData } from '../../../../api/login/login';
 import { faceDelete } from '../../../../api/face/faceDelete';
 
 import Icon from '../../../common/icon/Icon';
@@ -11,18 +9,20 @@ import Popup from '../../../common/popup/Popup';
 import TxtBtn from '../../../common/button/txtbtn/TxtBtn';
 import IcnBtn from '../../../common/button/icnbtn/IcnBtn';
 import * as S from './FaceDataCard.style';
+import useUserData from '../../../../hooks/useUserData';
 
 const FaceDataCard = () => {
   const theme = useTheme();
   const navigate = useNavigate();
   const { userInfo } = useAuthStore();
+  const { refetchUserData } = useUserData();
 
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [popupState, setPopupState] = useState<
     'register' | 'reRegister' | 'deleteInfo'
   >('register');
 
-  const [hasFace, sethasFace] = useState(userInfo?.hasFace ?? false);
+  const hasFace = userInfo?.hasFace ?? false;
 
   const openPopupWithState = (state: typeof popupState) => {
     setPopupState(state);
@@ -38,8 +38,7 @@ const FaceDataCard = () => {
   const onDelete = async () => {
     try {
       await faceDelete();
-      const updated = await getUserData();
-      sethasFace(updated.hasFace);
+      await refetchUserData();
       closePopup();
     } catch (error) {
       alert('얼굴 정보 삭제에 실패했습니다.');

--- a/src/components/common/button/btn/Btn.style.ts
+++ b/src/components/common/button/btn/Btn.style.ts
@@ -15,6 +15,7 @@ export const StyledButton = styled.button<StyledButtonProps>`
   font: var(--font-title-s);
   border-radius: var(--radius-8);
   width: 89px;
+  cursor: pointer;
 
   ${({ theme, variant, isBlue }) => {
     switch (variant) {

--- a/src/components/common/button/icnbtn/IcnBtn.style.ts
+++ b/src/components/common/button/icnbtn/IcnBtn.style.ts
@@ -5,8 +5,8 @@ export const StyledButton = styled.button`
   padding: var(--spacing-0);
   border: none;
   margin: var(--spacing-0);
-
   width: fit-content;
   height: fit-content;
   background-color: ${({ theme }) => theme.colors.background.white};
+  cursor: pointer;
 `;

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -3,6 +3,7 @@ import Icon from '../icon/Icon.tsx';
 import IcnBtn from '../button/icnbtn/IcnBtn.tsx';
 import Sheet from '../sheet/Sheet.tsx';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface HeaderProps {
   icon?: boolean;
@@ -10,6 +11,11 @@ interface HeaderProps {
 
 export const Header: React.FC<HeaderProps> = ({ icon }) => {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate('/');
+  };
 
   // Sheet를 여는 함수
   const openSheet = () => {
@@ -23,7 +29,9 @@ export const Header: React.FC<HeaderProps> = ({ icon }) => {
 
   return (
     <S.HeaderContainer>
-      <Icon name="logo" size="l" />
+      <IcnBtn onClick={handleClick}>
+        <Icon name="logo" size="l" />
+      </IcnBtn>
       {icon && (
         <IcnBtn onClick={openSheet}>
           <Icon name="strokemenu" size="mn" />

--- a/src/components/common/icon/Icon.style.ts
+++ b/src/components/common/icon/Icon.style.ts
@@ -12,6 +12,7 @@ const ICON_SIZES = {
 };
 
 export const ResponsiveIcon = styled.div<{ size: keyof typeof ICON_SIZES }>`
+  /* cursor: pointer; */
   ${media.mobile} {
     width: ${({ size }) => ICON_SIZES[size].mobile}px;
     height: ${({ size }) => ICON_SIZES[size].mobile}px;

--- a/src/components/common/layout/ResponsiveLayout.style.ts
+++ b/src/components/common/layout/ResponsiveLayout.style.ts
@@ -13,6 +13,7 @@ export const HeaderWrapper = styled.header`
   top: 0;
   left: 0;
   width: 100%;
+  z-index: 500;
 `;
 
 export const MarginTop = styled.header`

--- a/src/components/common/notify/Notify.style.ts
+++ b/src/components/common/notify/Notify.style.ts
@@ -8,6 +8,8 @@ export const NotifyContainer = styled.div`
   align-items: center;
   background-color: ${({ theme }) => theme.colors.background.weak};
   border-radius: var(--radius-8);
+  user-select: none;
+  cursor: pointer;
 `;
 
 export const TextWrapper = styled.div`

--- a/src/components/common/table/Table.style.ts
+++ b/src/components/common/table/Table.style.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const TableContainer = styled.table`
   width: 100%;
   margin: 12px 0px;
+  user-select: none;
 `;
 
 export const Caption = styled.caption`

--- a/src/hooks/useUserData.ts
+++ b/src/hooks/useUserData.ts
@@ -20,5 +20,6 @@ export default function useUserData() {
 
   return {
     userDataQuery,
+    refetchUserData: userDataQuery.refetch,
   };
 }

--- a/src/pages/admin/VisitorStatus.style.ts
+++ b/src/pages/admin/VisitorStatus.style.ts
@@ -44,7 +44,7 @@ export const FloatingBtnContainer = styled.div`
   position: fixed;
   right: var(--spacing-20);
   bottom: var(--spacing-44);
-  z-index: 1000;
+  z-index: 200;
 
   ${media.desktop} {
     right: var(--spacing-80);

--- a/src/pages/admin/VisitorStatus.tsx
+++ b/src/pages/admin/VisitorStatus.tsx
@@ -55,7 +55,7 @@ const VisitorStatus = () => {
   }));
 
   return (
-    <ResponsiveLayout>
+    <ResponsiveLayout hasHeader={true} hasHeaderIcon={true}>
       <S.TitleContainer>
         <S.Title>행사명</S.Title>
         <S.Description>예매자의 참석 여부 데이터를 볼 수 있어요</S.Description>

--- a/src/pages/admin/Visitors.style.ts
+++ b/src/pages/admin/Visitors.style.ts
@@ -44,7 +44,7 @@ export const FloatingBtnContainer = styled.div`
   position: fixed;
   right: var(--spacing-20);
   bottom: var(--spacing-44);
-  z-index: 1000;
+  z-index: 200;
 
   ${media.desktop} {
     right: var(--spacing-80);

--- a/src/pages/user/FaceRegistration.tsx
+++ b/src/pages/user/FaceRegistration.tsx
@@ -6,12 +6,14 @@ import { faceRegister } from '../../api/face/faceRegister';
 import { Toast } from '../../components/common/toast/Toast';
 import { faceMsg, ToastState } from '../../constant/faceMsg';
 import Loading from '../../components/common/loading/Loading';
+import { useNavigate } from 'react-router-dom';
 
 const FaceRegistration = () => {
   const webcamRef = useRef<Webcam | null>(null);
   const [hasCaptured, setHasCaptured] = useState(false);
   const [faceState, setFaceState] = useState<ToastState>('default');
   const [isCameraVisible, setIsCameraVisible] = useState(true);
+  const navigate = useNavigate();
 
   const handleFaceDetected = (captureImage: () => void) => {
     if (!hasCaptured) {
@@ -50,7 +52,7 @@ const FaceRegistration = () => {
       const stream = video?.srcObject as MediaStream;
       stream?.getTracks().forEach((track) => track.stop());
 
-      window.location.href = '/profile';
+      navigate('/profile');
     }
   }, [isCameraVisible]);
 

--- a/src/pages/user/Profile.style.ts
+++ b/src/pages/user/Profile.style.ts
@@ -16,4 +16,6 @@ export const CardWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
+  user-select: none;
+  cursor: auto;
 `;


### PR DESCRIPTION
## 🚀 반영 브랜치
`fix/185-update-user-data` → `dev`

## 📝 작업 내용

- 얼굴 정보 변경 시 tanstack query를 사용하여 유저 데이터를 자동으로 갱신하고 즉시 반영되도록 개선
- 아이콘 스타일 개선 (`cursor: pointer`, `user-select: none` 등으로 ux 향상)

## 🌠 스크린샷

## ✏️ 후속 작업

## 📌 이슈 번호

- #185 
