### PR TITLE
[FIX: linkUserReservation API 연결 추가하고 본인인증 onSubmit에 API 호출하기

### DIFF
--- a/src/api/authorization/linkUserReservation.ts
+++ b/src/api/authorization/linkUserReservation.ts
@@ -1,0 +1,13 @@
+import API from '../axiosIntance';
+
+export const linkUserReservation = async (phone: string) => {
+  try {
+    const response = await API.post('/reservation/link-user', {
+      phone: phone,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log('유저 예약내역 연결 실패', error);
+  }
+};

--- a/src/pages/login/authorization/AuthorizationCallback.tsx
+++ b/src/pages/login/authorization/AuthorizationCallback.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import ResponsiveLayout from '../../../components/common/layout/ResponsiveLayout';
 import AuthorizationForm from './AuthorizationForm';
 import { editUsersPhone } from '../../../api/authorization/editUsersPhone';
+import { linkUserReservation } from '../../../api/authorization/linkUserReservation';
 import * as S from './Authorization.style';
 
 const AuthorizationCallback = () => {
@@ -13,7 +14,6 @@ const AuthorizationCallback = () => {
   const hasPhone = searchParams.get('hasPhone');
 
   useEffect(() => {
-    // hasPhone이 true면 인증 이미 완료된 상태 → 바로 대시보드로
     if (hasPhone === 'true') {
       navigate('/dashboard');
     }
@@ -22,11 +22,19 @@ const AuthorizationCallback = () => {
   const handlePhoneSubmit = async (phone: string) => {
     try {
       await editUsersPhone(phone);
-      alert('전화번호 인증 완료!');
-      navigate('/dashboard');
     } catch {
       alert('전화번호 인증 실패. 다시 시도해주세요.');
+      return;
     }
+
+    try {
+      await linkUserReservation(phone);
+    } catch {
+      alert('예약 정보 연결 실패. 관리자에게 문의해주세요.');
+      return;
+    }
+
+    navigate('/dashboard');
   };
 
   return (


### PR DESCRIPTION
## 🚀 반영 브랜치
`fix/188-oauth-user-link` → `dev`

## 📝 작업 내용
- reservation/link-user API를 사용하여 oauth에서 본인인증 이후 사용자 링크 구현

## 🌠 스크린샷

## ✏️ 후속 작업

## 📌 이슈 번호

- #188 
