### PR TITLE
[FIX]: SSE 연결 해제 로직 수정 및 unsubscribe API 반영

### DIFF
--- a/src/api/sse/unsubscribe.ts
+++ b/src/api/sse/unsubscribe.ts
@@ -1,0 +1,17 @@
+import API from './../axiosIntance';
+
+export const disconnectSSE = async (
+  conferenceId: number,
+  sessionId?: number,
+) => {
+    const url = sessionId
+    ? `/sse/unsubscribe?conferenceId=${conferenceId}&sessionId=${sessionId}`
+    : `/sse/unsubscribe?conferenceId=${conferenceId}`;
+
+  try {
+    const response = await API.delete(url);
+    console.log(response.data.message);
+  } catch (error) {
+    console.error('SSE 연결 종료 오류:', error);
+  }
+};

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { disconnectSSE } from '../api/sse/unsubscribe';
 
 interface EntryCounts {
   conferenceAttend: number;
@@ -37,9 +38,12 @@ export default function useSSE(conferenceId: number, sessionIds: number[]) {
     });
 
     // 세션 SSE 연결
+    const sessionEventSources: EventSource[] = [];
+
     sessionIds.forEach((sessionId) => {
       const sessionUrl = `${baseSSEUrl}?conferenceId=${conferenceId}&sessionId=${sessionId}`;
       const sessionEventSource = new EventSource(sessionUrl);
+      sessionEventSources.push(sessionEventSource);
 
       sessionEventSource.addEventListener('AttendanceCount', (event) => {
         try {
@@ -58,15 +62,17 @@ export default function useSSE(conferenceId: number, sessionIds: number[]) {
     });
 
     return () => {
-      conferenceEventSource.close();
-      sessionIds.forEach((sessionId) => {
-        const sessionEventSource = new EventSource(
-          `${baseSSEUrl}?conferenceId=${conferenceId}&sessionId=${sessionId}`,
-        );
-        sessionEventSource.close();
+      sessionEventSources.forEach((source, index) => {
+        console.log(`세션 ${sessionIds[index]} SSE 연결 해제`);
+        source.close();
+        disconnectSSE(conferenceId, sessionIds[index]);
       });
+
+      conferenceEventSource.close();
+      disconnectSSE(conferenceId);
+      console.log(`컨퍼런스 ${conferenceId} SSE 해제 완료`);
     };
-  }, [conferenceId, sessionIds]);
+  }, []);
 
   return entryCounts;
 }


### PR DESCRIPTION
## 🚀 반영 브랜치
`fix/205-sse-unsubscribe` → `dev`

## 📝 작업 내용

프론트에서 SSE 연결이 끊기는데 백엔드에서 끊기지 않아 unsubscribe API를 추가하여 명확히 종료하도록 함

## 🌠 스크린샷

## ✏️ 후속 작업

## 📌 이슈 번호

- #205 
